### PR TITLE
Refactor output

### DIFF
--- a/src/main/php/web/Response.class.php
+++ b/src/main/php/web/Response.class.php
@@ -8,7 +8,7 @@ use web\io\WriteChunks;
  *
  * @test  xp://web.unittest.ResponseTest
  */
-class Response implements \io\streams\OutputStream {
+class Response {
   private $target;
   private $flushed= false;
   private $status= 200;
@@ -67,25 +67,6 @@ class Response implements \io\streams\OutputStream {
   }
 
   /**
-   * Writes to response, flushing it if necessary.
-   *
-   * @return void
-   */
-  public function write($bytes) {
-    $this->flushed || $this->flush();
-    $this->target->write($bytes);
-  }
-
-  /**
-   * Closes response
-   *
-   * @return void
-   */
-  public function close() {
-    $this->flushed || $this->flush();
-  }
-
-  /**
    * Transfers a stream
    *
    * @param  io.streams.InputStream $in
@@ -96,18 +77,18 @@ class Response implements \io\streams\OutputStream {
     $this->headers['Content-Type']= $mediaType;
     if (null === $size) {
       $this->headers['Transfer-Encoding']= 'chunked';
-      $out= new WriteChunks($this->target);
+      $target= new WriteChunks($this->target);
     } else {
       $this->headers['Content-Length']= $size;
-      $out= $this;
+      $target= $this->target;
     }
 
     $this->flush();
     while ($in->available()) {
-      $out->write($in->read());
+      $target->write($in->read());
     }
 
-    $out->close();
+    $target->finish();
     $in->close();
   }
 
@@ -115,6 +96,8 @@ class Response implements \io\streams\OutputStream {
     $this->headers['Content-Type']= $mediaType;
     $this->headers['Content-Length']= strlen($content);
     $this->flush();
+
     $this->target->write($content);
+    $this->target->finish();
   }
 }

--- a/src/main/php/web/Response.class.php
+++ b/src/main/php/web/Response.class.php
@@ -83,7 +83,8 @@ class Response {
       $target= $this->target;
     }
 
-    $this->flush();
+    $target->begin($this->status, $this->message, $this->headers);
+    $this->flushed= true;
     while ($in->available()) {
       $target->write($in->read());
     }

--- a/src/main/php/web/io/Output.class.php
+++ b/src/main/php/web/io/Output.class.php
@@ -6,4 +6,6 @@ interface Output {
 
   public function write($bytes);
 
+  public function finish();
+
 }

--- a/src/main/php/web/io/WriteChunks.class.php
+++ b/src/main/php/web/io/WriteChunks.class.php
@@ -5,7 +5,7 @@
  *
  * @see   https://tools.ietf.org/html/rfc2616#section-3.6.1
  */
-class WriteChunks {
+class WriteChunks implements Output {
   private $target;
 
   /** @param io.streams.OutputStream $target */
@@ -13,13 +13,31 @@ class WriteChunks {
     $this->target= $target;
   }
 
-  /** @param string $chunk */
+  /**
+   * Begins output
+   *
+   * @param  int $status
+   * @param  string $message
+   * @param  [:string] $headers
+   * @return void
+   */
+  public function begin($status, $message, $headers) {
+    $this->target->begin($status, $message, $headers);
+  }
+
+  /**
+   * Writes a chunk of data
+   *
+   * @param  string $chunk
+   * @return void
+   */
   public function write($chunk) {
     $this->target->write(dechex(strlen($chunk))."\r\n".$chunk."\r\n");
   }
 
   /** @return void */
-  public function close() {
+  public function finish() {
     $this->target->write("0\r\n\r\n");
+    $this->target->finish();
   }
 }

--- a/src/main/php/xp/web/Output.class.php
+++ b/src/main/php/xp/web/Output.class.php
@@ -18,4 +18,8 @@ class Output implements \web\io\Output {
   public function write($bytes) {
     $this->socket->write($bytes);
   }
+
+  public function finish() {
+    // NOOP
+  }
 }

--- a/src/test/php/web/unittest/TestOutput.class.php
+++ b/src/test/php/web/unittest/TestOutput.class.php
@@ -14,4 +14,8 @@ class TestOutput implements \web\io\Output {
   public function write($bytes) {
     $this->bytes.= $bytes;
   }
+
+  public function finish() {
+    // NOOP
+  }
 }


### PR DESCRIPTION
This pull request:

* Adds a `finish()` method to `web.io.Output`. This method is called by both `transfer()` (*which works on streams*) and `send()` (*which uses strings as input*) after the end. Subsequently, the `web.io.WriteChunks` is changed to implement this interface. 
* Changes the `web.Response` class no longer to implement `io.streams.OutputStream`. The `write()` method behaved in a way that may be counterintuitive to people, they need to use one of the afforementioned send() or transfer() methods instead.