### PR TITLE
Ranges support

### DIFF
--- a/src/main/php/web/handler/FilesFrom.class.php
+++ b/src/main/php/web/handler/FilesFrom.class.php
@@ -41,10 +41,9 @@ class FilesFrom implements \web\Handler {
    * @param  int $length
    */
   private function copy($output, $file, $length) {
-    $written= 0;
-    while ($written < $length && ($chunk= $file->read(min(8192, $length - $written)))) {
+    while ($length && $chunk= $file->read(min(8192, $length))) {
       $output->write($chunk);
-      $written+= strlen($chunk);
+      $length-= strlen($chunk);
     }
   }
 

--- a/src/main/php/web/handler/FilesFrom.class.php
+++ b/src/main/php/web/handler/FilesFrom.class.php
@@ -21,13 +21,25 @@ class FilesFrom implements \web\Handler {
    */
   public function handle($request, $response) {
     $target= new Path($this->path, $request->uri()->path());
-
     if ($target->isFolder()) {
       $file= new File($target, 'index.html');
     } else {
       $file= $target->asFile();
     }
 
+    $this->serve($request, $response, $file);
+  }
+
+  /**
+   * Handles a request
+   *
+   * @param   web.Request $request
+   * @param   web.Response $response
+   * @param   io.File|io.Path|string $target
+   * @return  void
+   */
+  public function serve($request, $response, $target) {
+    $file= $target instanceof File ? $target : new File($target);
     if (!$file->exists()) {
       $response->answer(404, 'Not Found');
       $response->send('The file \''.$request->uri()->path().'\' was not found', 'text/plain');

--- a/src/main/php/web/handler/FilesFrom.class.php
+++ b/src/main/php/web/handler/FilesFrom.class.php
@@ -31,7 +31,7 @@ class FilesFrom implements \web\Handler {
   }
 
   /**
-   * Handles a request
+   * Serves a single file
    *
    * @param   web.Request $request
    * @param   web.Response $response
@@ -66,6 +66,13 @@ class FilesFrom implements \web\Handler {
 
       // Handle "bytes=-4", requesting last four bytes
       if ($start < 0) $start+= $size;
+
+      if ($start >= $size || $end >= $size || $end < $start) {
+        $response->answer(416, 'Range Not Satisfiable');
+        $response->header('Content-Range', 'bytes */'.$size);
+        $response->flush();
+        return;
+      }
 
       $response->answer(206, 'Partial Content');
       $response->header('Content-Type', $mimeType);

--- a/src/main/php/web/io/Range.class.php
+++ b/src/main/php/web/io/Range.class.php
@@ -1,0 +1,16 @@
+<?php namespace web\io;
+
+class Range {
+  private $start, $end;
+
+  public function __construct($start, $end) {
+    $this->start= $start;
+    $this->end= $end;
+  }
+
+  public function start() { return $this->start; }
+
+  public function end() { return $this->end; }
+
+  public function length() { return $this->end - $this->start + 1; }
+}

--- a/src/main/php/web/io/Range.class.php
+++ b/src/main/php/web/io/Range.class.php
@@ -1,16 +1,26 @@
 <?php namespace web\io;
 
+/* @see xp://web.io.Ranges */
 class Range {
   private $start, $end;
 
+  /**
+   * Creates a new range
+   *
+   * @param  int $start
+   * @param  int $end
+   */
   public function __construct($start, $end) {
     $this->start= $start;
     $this->end= $end;
   }
 
+  /** @return int */
   public function start() { return $this->start; }
 
+  /** @return int */
   public function end() { return $this->end; }
 
+  /** @return int */
   public function length() { return $this->end - $this->start + 1; }
 }

--- a/src/main/php/web/io/Ranges.class.php
+++ b/src/main/php/web/io/Ranges.class.php
@@ -1,8 +1,12 @@
 <?php namespace web\io;
 
+use lang\FormatException;
+use lang\IllegalArgumentException;
+
 /**
  * Range Requests
  *
+ * @test  xp://web.unittest.RangesTest
  * @see   https://tools.ietf.org/html/rfc7233
  */
 class Ranges {
@@ -14,8 +18,13 @@ class Ranges {
    * @param  string $unit
    * @param  web.io.Range[] $sets
    * @param  int $complete
+   * @throws lang.IllegalArgumentException
    */
   public function __construct($unit, $sets, $complete) {
+    if (empty($sets)) {
+      throw new IllegalArgumentException('Sets may not be empty');
+    }
+
     $this->unit= $unit;
     $this->sets= $sets;
     $this->complete= $complete;
@@ -27,11 +36,14 @@ class Ranges {
    * @param  string $input
    * @param  int $complete
    * @return self or NULL if input is NULL.
+   * @throws lang.FormatException
    */
   public static function in($input, $complete) {
     if (null === $input) return null;
 
-    sscanf($input, '%[^=]=%[0-9-,]', $unit, $set);
+    if (2 !== sscanf($input, '%[^=]=%[0-9-,]%s', $unit, $set, $_)) {
+      throw new FormatException('Invalid range "'.$input.'"');
+    }
 
     $sets= [];
     foreach (explode(',', $set) as $range) {

--- a/src/main/php/web/io/Ranges.class.php
+++ b/src/main/php/web/io/Ranges.class.php
@@ -1,0 +1,77 @@
+<?php namespace web\io;
+
+/**
+ * Range Requests
+ *
+ * @see   https://tools.ietf.org/html/rfc7233
+ */
+class Ranges {
+  private $unit, $sets, $complete;
+
+  /**
+   * Creates a ranges instance
+   *
+   * @param  string $unit
+   * @param  web.io.Range[] $sets
+   * @param  int $complete
+   */
+  public function __construct($unit, $sets, $complete) {
+    $this->unit= $unit;
+    $this->sets= $sets;
+    $this->complete= $complete;
+  }
+
+  /**
+   * Returns a Ranges instance parsed from a given input
+   *
+   * @param  string $input
+   * @param  int $complete
+   * @return self or NULL if input is NULL.
+   */
+  public static function in($input, $complete) {
+    if (null === $input) return null;
+
+    sscanf($input, '%[^=]=%[0-9-,]', $unit, $set);
+
+    $sets= [];
+    foreach (explode(',', $set) as $range) {
+      $end= $complete - 1;
+      sscanf($range, '%d-%d', $start, $end);
+      $start < 0 && $start+= $complete;
+      $sets[]= new Range($start, $end);
+    }
+
+    return new self($unit, $sets, $complete);
+  }
+
+  /** @return string */
+  public function unit() { return $this->unit; }
+
+  /** @return web.io.Range[] */
+  public function sets() { return $this->sets; }
+
+  /** @return int */
+  public function complete() { return $this->complete; }
+
+  /** @return web.io.Range */
+  public function single() { return 1 === sizeof($this->sets) ? $this->sets[0] : null; }
+
+  /** @return bool */
+  public function satisfiable() {
+    $limit= $this->complete - 1;
+    foreach ($this->sets as $r) {
+      if ($r->start() > $limit || $r->end() > $limit || $r->end() < $r->start()) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Formats a given range
+   *
+   * @param  web.io.Range $range
+   * @return string
+   */
+  public function format($range) {
+    return sprintf('%s %d-%d/%d', $this->unit, $range->start(), $range->end(), $this->complete);
+  }
+}

--- a/src/main/php/xp/web/Runner.class.php
+++ b/src/main/php/xp/web/Runner.class.php
@@ -92,7 +92,7 @@ class Runner {
 
     for ($i= 0; $i < sizeof($args); $i++) {
        if ('-r' === $args[$i]) {
-        $docroot= $webroot->resolve($args[++$i]);
+        $docroot= $args[++$i];
       } else if ('-a' === $args[$i]) {
         $address= $args[++$i];
       } else if ('-p' === $args[$i]) {

--- a/src/main/php/xp/web/ServeDocumentRootStatically.class.php
+++ b/src/main/php/xp/web/ServeDocumentRootStatically.class.php
@@ -1,12 +1,12 @@
 <?php namespace xp\web;
 
 use web\Application;
-use web\handler\FilesIn;
+use web\handler\FilesFrom;
 
 class ServeDocumentRootStatically extends Application {
 
   /** @return web.Routing|[:var] */
   public function routes() {
-    return ['/' => new FilesIn($this->environment->docroot())];
+    return ['/' => new FilesFrom($this->environment->docroot())];
   }
 }

--- a/src/test/php/web/unittest/RangesTest.class.php
+++ b/src/test/php/web/unittest/RangesTest.class.php
@@ -1,0 +1,114 @@
+<?php namespace web\unittest;
+
+use lang\FormatException;
+use lang\IllegalArgumentException;
+use web\io\Ranges;
+use web\io\Range;
+
+class RangesTest extends \unittest\TestCase {
+  const UNIT = 'bytes';
+  const COMPLETE = 100;
+
+  /**
+   * Creates sets
+   *
+   * @param  int $num
+   * @return web.io.Range[]
+   */
+  private function newSets($num) {
+    $r= [];
+    for ($i= 0; $i < $num; $i++) {
+      $r[]= new Range($i, $i + self::COMPLETE - 1);
+    }
+    return $r;
+  }
+
+  #[@test]
+  public function can_create() {
+    new Ranges(self::UNIT, $this->newSets(1), self::COMPLETE);
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function sets_may_not_be_empty() {
+    new Ranges(self::UNIT, [], self::COMPLETE);
+  }
+
+  #[@test, @values(['bytes', 'characters'])]
+  public function unit($unit) {
+    $this->assertEquals($unit, (new Ranges($unit, $this->newSets(1), self::COMPLETE))->unit());
+  }
+
+  #[@test]
+  public function complete() {
+    $this->assertEquals(self::COMPLETE, (new Ranges(self::UNIT, $this->newSets(1), self::COMPLETE))->complete());
+  }
+
+  #[@test, @values([1, 2])]
+  public function sets($num) {
+    $sets= $this->newSets($num);
+    $this->assertEquals($sets, (new Ranges(self::UNIT, $sets, self::COMPLETE))->sets());
+  }
+
+  #[@test]
+  public function single_set() {
+    $sets= $this->newSets(1);
+    $this->assertEquals($sets[0], (new Ranges(self::UNIT, $sets, self::COMPLETE))->single());
+  }
+
+  #[@test]
+  public function multiple_sets() {
+    $this->assertNull((new Ranges(self::UNIT, $this->newSets(2), self::COMPLETE))->single());
+  }
+
+  #[@test]
+  public function no_ranges_in_null() {
+    $this->assertNull(Ranges::in(null, self::COMPLETE));
+  }
+
+  #[@test, @values([
+  #  [[new Range(0, 99)], true],
+  #  [[new Range(99, 99)], true],
+  #  [[new Range(0, 100)], false],
+  #  [[new Range(100, 100)], false],
+  #  [[new Range(100, 99)], false],
+  #  [[new Range(100, 0)], false]
+  #])]
+  public function satisfiable($sets, $expected) {
+    $this->assertEquals($expected, (new Ranges(self::UNIT, $sets, 100))->satisfiable());
+  }
+
+  #[@test]
+  public function single_set_in() {
+    $this->assertEquals(
+      new Ranges('bytes', [new Range(0, 99)], self::COMPLETE),
+      Ranges::in('bytes=0-99', self::COMPLETE)
+    );
+  }
+
+  #[@test]
+  public function multiple_sets_in() {
+    $last= self::COMPLETE - 1;
+    $this->assertEquals(
+      new Ranges('bytes', [new Range(0, 0), new Range($last, $last)], self::COMPLETE),
+      Ranges::in('bytes=0-0,-1', self::COMPLETE)
+    );
+  }
+
+  #[@test, @expect(FormatException::class), @values([
+  #  'bytes',
+  #  'bytes=',
+  #  'bytes=a-c',
+  #  'bytes=a-',
+  #  'bytes=-c',
+  #  'bytes=0-0,INVALID',
+  #])]
+  public function invalid_range($input) {
+    Ranges::in($input, self::COMPLETE);
+  }
+
+  #[@test]
+  public function format() {
+    $range= new Range(0, 99);
+    $this->assertEquals('bytes 0-99/100', (new Ranges('bytes', [$range], 100))->format($range));
+  }
+}

--- a/src/test/php/web/unittest/RangesTest.class.php
+++ b/src/test/php/web/unittest/RangesTest.class.php
@@ -80,7 +80,7 @@ class RangesTest extends \unittest\TestCase {
   #[@test]
   public function single_set_in() {
     $this->assertEquals(
-      new Ranges('bytes', [new Range(0, 99)], self::COMPLETE),
+      new Ranges('bytes', [new Range(0, self::COMPLETE - 1)], self::COMPLETE),
       Ranges::in('bytes=0-99', self::COMPLETE)
     );
   }
@@ -91,6 +91,22 @@ class RangesTest extends \unittest\TestCase {
     $this->assertEquals(
       new Ranges('bytes', [new Range(0, 0), new Range($last, $last)], self::COMPLETE),
       Ranges::in('bytes=0-0,-1', self::COMPLETE)
+    );
+  }
+
+  #[@test, @values([1, 10])]
+  public function last_n($offset) {
+    $this->assertEquals(
+      new Ranges('bytes', [new Range(self::COMPLETE - $offset, self::COMPLETE - 1)], self::COMPLETE),
+      Ranges::in('bytes=-'.$offset, self::COMPLETE)
+    );
+  }
+
+  #[@test, @values([0, 1])]
+  public function starting_at_until_end($offset) {
+    $this->assertEquals(
+      new Ranges('bytes', [new Range($offset, self::COMPLETE - 1)], self::COMPLETE),
+      Ranges::in('bytes='.$offset.'-', self::COMPLETE)
     );
   }
 

--- a/src/test/php/web/unittest/handler/FilesFromTest.class.php
+++ b/src/test/php/web/unittest/handler/FilesFromTest.class.php
@@ -61,6 +61,7 @@ class FilesFromTest extends \unittest\TestCase {
 
     $this->assertResponse(
       "HTTP/1.1 200 OK\r\n".
+      "Accept-Ranges: bytes\r\n".
       "Last-Modified: <Date>\r\n".
       "Content-Type: text/html\r\n".
       "Content-Length: 4\r\n".
@@ -95,6 +96,7 @@ class FilesFromTest extends \unittest\TestCase {
 
     $this->assertResponse(
       "HTTP/1.1 200 OK\r\n".
+      "Accept-Ranges: bytes\r\n".
       "Last-Modified: <Date>\r\n".
       "Content-Type: text/html\r\n".
       "Content-Length: 4\r\n".
@@ -136,6 +138,69 @@ class FilesFromTest extends \unittest\TestCase {
       "Content-Length: 26\r\n".
       "\r\n".
       "The file '/' was not found",
+      $out->bytes
+    );
+  }
+
+  #[@test]
+  public function range_with_start_and_end() {
+    $in= new TestInput('GET', '/', ['Range' => 'bytes=0-3']);
+    $out= new TestOutput(); 
+
+    $files= (new FilesFrom($this->pathWith(['index.html' => 'Homepage'])));
+    $files->handle(new Request($in), new Response($out));
+
+    $this->assertResponse(
+      "HTTP/1.1 206 Partial Content\r\n".
+      "Accept-Ranges: bytes\r\n".
+      "Last-Modified: <Date>\r\n".
+      "Content-Type: text/html\r\n".
+      "Content-Range: bytes 0-3/8\r\n".
+      "Content-Length: 4\r\n".
+      "\r\n".
+      "Home",
+      $out->bytes
+    );
+  }
+
+  #[@test]
+  public function range_from_offset_until_end() {
+    $in= new TestInput('GET', '/', ['Range' => 'bytes=4-']);
+    $out= new TestOutput(); 
+
+    $files= (new FilesFrom($this->pathWith(['index.html' => 'Homepage'])));
+    $files->handle(new Request($in), new Response($out));
+
+    $this->assertResponse(
+      "HTTP/1.1 206 Partial Content\r\n".
+      "Accept-Ranges: bytes\r\n".
+      "Last-Modified: <Date>\r\n".
+      "Content-Type: text/html\r\n".
+      "Content-Range: bytes 4-7/8\r\n".
+      "Content-Length: 4\r\n".
+      "\r\n".
+      "page",
+      $out->bytes
+    );
+  }
+
+  #[@test]
+  public function range_last_four_bytes() {
+    $in= new TestInput('GET', '/', ['Range' => 'bytes=-4']);
+    $out= new TestOutput(); 
+
+    $files= (new FilesFrom($this->pathWith(['index.html' => 'Homepage'])));
+    $files->handle(new Request($in), new Response($out));
+
+    $this->assertResponse(
+      "HTTP/1.1 206 Partial Content\r\n".
+      "Accept-Ranges: bytes\r\n".
+      "Last-Modified: <Date>\r\n".
+      "Content-Type: text/html\r\n".
+      "Content-Range: bytes 4-7/8\r\n".
+      "Content-Length: 4\r\n".
+      "\r\n".
+      "page",
       $out->bytes
     );
   }

--- a/src/test/php/web/unittest/handler/FilesFromTest.class.php
+++ b/src/test/php/web/unittest/handler/FilesFromTest.class.php
@@ -190,12 +190,12 @@ class FilesFromTest extends \unittest\TestCase {
     );
   }
 
-  #[@test]
-  public function range_last_four_bytes() {
+  #[@test, @values([0, 8192, 10000])]
+  public function range_last_four_bytes($offset) {
     $in= new TestInput('GET', '/', ['Range' => 'bytes=-4']);
     $out= new TestOutput(); 
 
-    $files= (new FilesFrom($this->pathWith(['index.html' => 'Homepage'])));
+    $files= (new FilesFrom($this->pathWith(['index.html' => str_repeat('*', $offset).'Homepage'])));
     $files->handle(new Request($in), new Response($out));
 
     $this->assertResponse(
@@ -203,7 +203,7 @@ class FilesFromTest extends \unittest\TestCase {
       "Accept-Ranges: bytes\r\n".
       "Last-Modified: <Date>\r\n".
       "Content-Type: text/html\r\n".
-      "Content-Range: bytes 4-7/8\r\n".
+      "Content-Range: bytes ".($offset + 4)."-".($offset + 7)."/".($offset + 8)."\r\n".
       "Content-Length: 4\r\n".
       "\r\n".
       "page",


### PR DESCRIPTION
This pull request implements support for the `Range` header in `web.handler.FilesFrom`, as requested in #1 

```sh
Range: 0-99    # First 100 bytes
Range: -100    # Last 100 bytes
Range: 100-    # Everything from the one hundred first byte until the end
Range: 100-199 # 100 bytes, starting from the one hundred first byte 
```

See https://tools.ietf.org/html/rfc7233