### PR TITLE
Response::error()

### DIFF
--- a/src/main/php/web/Application.class.php
+++ b/src/main/php/web/Application.class.php
@@ -1,5 +1,7 @@
 <?php namespace web;
 
+use lang\Throwable;
+
 /**
  * Application is at the heart at every web project.
  *
@@ -44,14 +46,23 @@ abstract class Application implements \lang\Value {
   protected abstract function routes();
 
   /**
-   * Service delegates to the routing, calling its `service()` method.
+   * Service delegates to the routing, calling its `service()` method. Takes care
+   * of handling exceptions raised from routing, setting response's error member.
    *
    * @param  web.Request $request
    * @param  web.Response $response
    * @return void
    */
   public function service($request, $response) {
-    $this->routing()->service($request, $response);
+    try {
+      $this->routing()->service($request, $response);
+    } catch (Throwable $t) {
+      $response->error($t);
+    } catch (\Throwable $e) {   // PHP7
+      $response->error(Throwable::wrap($e));
+    } catch (\Exception $e) {   // PHP5
+      $response->error(Throwable::wrap($e));
+    }
   }
 
   /** @return string */

--- a/src/main/php/web/InternalServerError.class.php
+++ b/src/main/php/web/InternalServerError.class.php
@@ -1,13 +1,19 @@
 <?php namespace web;
 
+use lang\Throwable;
+
 class InternalServerError extends Error {
 
   /**
    * Creates a new internal server error
    *
-   * @param  php.Throwable $cause
+   * @param  php.Throwable|string $cause
    */
   public function __construct($cause) {
-    parent::__construct(500, $cause->getMessage(), $cause);
+    if ($cause instanceof Throwable) {
+      parent::__construct(500, $cause->getMessage(), $cause);
+    } else {
+      parent::__construct(500, $cause);
+    }
   }
 }

--- a/src/main/php/web/Response.class.php
+++ b/src/main/php/web/Response.class.php
@@ -39,8 +39,14 @@ class Response {
    *
    * @param  web.Error|lang.Throwable|string|int $cause
    * @param  string $message Only applicable if an integer is passed as cause
+   * @return void
    */
   public function error($cause, $message= null) {
+    if (null === $cause) {
+      $this->error= null;
+      return;
+    }
+
     if ($cause instanceof Error) {
       $this->error= $cause;
     } else if ($cause instanceof Throwable) {

--- a/src/test/php/web/unittest/ResponseTest.class.php
+++ b/src/test/php/web/unittest/ResponseTest.class.php
@@ -1,6 +1,8 @@
 <?php namespace web\unittest;
 
 use web\Response;
+use web\Error;
+use lang\IllegalStateException;
 use io\streams\MemoryInputStream;
 
 class ResponseTest extends \unittest\TestCase {
@@ -35,6 +37,41 @@ class ResponseTest extends \unittest\TestCase {
     $res= new Response(new TestOutput());
     $res->answer(201, 'Creation succeeded');
     $this->assertEquals('Creation succeeded', $res->message());
+  }
+
+  #[@test]
+  public function error_status() {
+    $res= new Response(new TestOutput());
+    $res->error(403);
+    $this->assertEquals('Error web.Error(#403: Forbidden)', $res->error->compoundMessage());
+  }
+
+  #[@test]
+  public function error_status_with_message() {
+    $res= new Response(new TestOutput());
+    $res->error(403, 'Go away!');
+    $this->assertEquals('Error web.Error(#403: Go away!)', $res->error->compoundMessage());
+  }
+
+  #[@test]
+  public function error_message() {
+    $res= new Response(new TestOutput());
+    $res->error('Crash');
+    $this->assertEquals('Error web.InternalServerError(#500: Crash)', $res->error->compoundMessage());
+  }
+
+  #[@test]
+  public function error_cause() {
+    $res= new Response(new TestOutput());
+    $res->error(new IllegalStateException('Crash'));
+    $this->assertEquals('Error web.InternalServerError(#500: Crash)', $res->error->compoundMessage());
+  }
+
+  #[@test]
+  public function error_instance() {
+    $res= new Response(new TestOutput());
+    $res->error(new Error(402));
+    $this->assertEquals('Error web.Error(#402: Payment Required)', $res->error->compoundMessage());
   }
 
   #[@test]

--- a/src/test/php/web/unittest/ResponseTest.class.php
+++ b/src/test/php/web/unittest/ResponseTest.class.php
@@ -40,6 +40,13 @@ class ResponseTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function no_error() {
+    $res= new Response(new TestOutput());
+    $res->error(null);
+    $this->assertNull($res->error);
+  }
+
+  #[@test]
   public function error_status() {
     $res= new Response(new TestOutput());
     $res->error(403);


### PR DESCRIPTION
## Current

```php
// Raise an exception
throw new Error(403);

// Alternatively, use answer()
$response->answer(403, 'Go away');
```

## Problems

* The only way to render the builtin error pages is to throw exceptions.
* Using answer(), the location the error was raised from gets lost
* Handling errors in a generic fashion will always require an if...

## New
```php
// Still possible
throw new Error(403);

// Also still possible, use this for expected situations
// * no stack trace in server log
// * no display or rendering of any sort
$response->answer(401);
$response->header('WWW-Authenticate', 'Basic realm="Admins"');

// Send errors in unexpected situtations:
// * will include stack trace in server log
// * will display error page (which includes stack trace in in dev environment)
$response->error(403);
$response->error(403, 'Go away');
$response->error(new Error(403));

// Strings are transformed to "500 Internal Server Error"
$response->error('Unreachable');

// All other exceptions get transformed to "500 Internal Server Error"
$response->error(new IllegalStateException('Unreachable'));
```

## Generic handling
```php
$this->status= ...;

// Current, error is either NULL for no error or a string
if ($this->error) {
  throw new Error($this->status, $this->error);
} else {
  $response->answer($this->status);
}

// New, error is either NULL for no error, an int, string, web.Error or lang.Throwable instance
$response->answer($this->status);
$response->error($this->error);
```