### PR TITLE
Cookie handling

### DIFF
--- a/src/main/php/web/Cookie.class.php
+++ b/src/main/php/web/Cookie.class.php
@@ -29,9 +29,9 @@ class Cookie {
   public function __construct($name, $value) {
     $this->name= $name;
     if (null === $value) {
-      $this->value= '""';
+      $this->value= '';
       $this->expires= new Date(time() - 86400 * 365);
-      $this->maxAge= -1;
+      $this->maxAge= 0;
     } else {
       $this->value= $value;
     }

--- a/src/main/php/web/Cookie.class.php
+++ b/src/main/php/web/Cookie.class.php
@@ -18,7 +18,7 @@ class Cookie {
   private $domain= null;
   private $secure= false;
   private $httpOnly= true;
-  private $sameSite= null;
+  private $sameSite= 'Lax';
 
   /**
    * Creates a new cookie
@@ -29,7 +29,7 @@ class Cookie {
   public function __construct($name, $value) {
     $this->name= $name;
     if (null === $value) {
-      $this->value= '';
+      $this->value= '""';
       $this->expires= new Date(time() - 86400 * 365);
       $this->maxAge= -1;
     } else {
@@ -112,7 +112,7 @@ class Cookie {
   /**
    * Switch whether to only transmit only to same site; preventing CSRF
    *
-   * @param  string $sameSite one of `Strict` or `Lax`.
+   * @param  string $sameSite one of "Strict", "Lax" or null (use the latter to remove)
    * @return self
    */
   public function sameSite($sameSite) {

--- a/src/main/php/web/Cookie.class.php
+++ b/src/main/php/web/Cookie.class.php
@@ -24,11 +24,17 @@ class Cookie {
    * Creates a new cookie
    *
    * @param  string $name
-   * @param  string $value
+   * @param  string $value Pass `null` to remove the cookie
    */
   public function __construct($name, $value) {
     $this->name= $name;
-    $this->value= $value;
+    if (null === $value) {
+      $this->value= '';
+      $this->expires= new Date(time() - 86400 * 365);
+      $this->maxAge= -1;
+    } else {
+      $this->value= $value;
+    }
   }
 
   /**

--- a/src/main/php/web/Cookie.class.php
+++ b/src/main/php/web/Cookie.class.php
@@ -1,0 +1,130 @@
+<?php namespace web;
+
+use util\Date;
+
+/**
+ * A HTTP/1.1 Cookie
+ *
+ * @see  https://tools.ietf.org/html/rfc6265
+ * @see  http://httpwg.org/http-extensions/draft-ietf-httpbis-cookie-same-site.html
+ * @see  https://www.owasp.org/index.php/SameSite
+ */
+class Cookie {
+  private $name, $value;
+
+  private $expires= null;
+  private $maxAge= null;
+  private $path= null;
+  private $domain= null;
+  private $secure= false;
+  private $httpOnly= true;
+  private $sameSite= null;
+
+  /**
+   * Creates a new cookie
+   *
+   * @param  string $name
+   * @param  string $value
+   */
+  public function __construct($name, $value) {
+    $this->name= $name;
+    $this->value= $value;
+  }
+
+  /**
+   * Set expiration date
+   *
+   * @param  int|string|util.Date $expires
+   * @return self
+   */
+  public function expires($expires) {
+    if (null === $expires) {
+      $this->expires= null;
+    } else if ($expires instanceof Date) {
+      $this->expires= $expires;
+    } else {
+      $this->expires= new Date($expires);
+    }
+    return $this;
+  }
+
+  /**
+   * Set maximum age in seconds. Use negative values to expire immediately.
+   *
+   * @param  int $maxAge
+   * @return self
+   */
+  public function maxAge($maxAge) {
+    $this->maxAge= $maxAge;
+    return $this;
+  }
+
+  /**
+   * Restricts to a given path. Use `/` for all paths on a given domain
+   *
+   * @param  string $path
+   * @return self
+   */
+  public function path($path) {
+    $this->path= $path;
+    return $this;
+  }
+
+  /**
+   * Restricts to a given domain. Prefix with `.` to make valid for all subdomains
+   *
+   * @param  string $domain
+   * @return self
+   */
+  public function domain($domain) {
+    $this->domain= $domain;
+    return $this;
+  }
+
+  /**
+   * Switch whether to only transmit via secure connections (HTTPS).
+   *
+   * @param  bool $secure
+   * @return self
+   */
+  public function secure($secure= true) {
+    $this->secure= $secure;
+    return $this;
+  }
+
+  /**
+   * Switch whether to only transmit via HTTP only, making it inaccessible to JavaScript.
+   *
+   * @param  bool $secure
+   * @return self
+   */
+  public function httpOnly($httpOnly= true) {
+    $this->httpOnly= $httpOnly;
+    return $this;
+  }
+
+  /**
+   * Switch whether to only transmit only to same site; preventing CSRF
+   *
+   * @param  string $sameSite one of `Strict` or `Lax`.
+   * @return self
+   */
+  public function sameSite($sameSite) {
+    $this->sameSite= $sameSite;
+    return $this;
+  }
+
+  /** @return string */
+  public function header() {
+    return (
+      $this->name.'='.$this->value.
+      (null === $this->expires ? '' : '; Expires='.gmdate('D, d M Y H:i:s \G\M\T', $this->expires->getTime())).
+      (null === $this->maxAge ? '' : '; Max-Age='.$this->maxAge).
+      (null === $this->path ? '' : '; Path='.$this->path).
+      (null === $this->domain ? '' : '; Domain='.$this->domain).
+      (null === $this->sameSite ? '' : '; SameSite='.$this->sameSite).
+      ($this->secure ? '; Secure' : '').
+      ($this->httpOnly ? '; HttpOnly' : '')
+    );
+  }
+}

--- a/src/main/php/web/Cookie.class.php
+++ b/src/main/php/web/Cookie.class.php
@@ -5,9 +5,10 @@ use util\Date;
 /**
  * A HTTP/1.1 Cookie
  *
- * @see  https://tools.ietf.org/html/rfc6265
- * @see  http://httpwg.org/http-extensions/draft-ietf-httpbis-cookie-same-site.html
- * @see  https://www.owasp.org/index.php/SameSite
+ * @see   https://tools.ietf.org/html/rfc6265
+ * @see   http://httpwg.org/http-extensions/draft-ietf-httpbis-cookie-same-site.html
+ * @see   https://www.owasp.org/index.php/SameSite
+ * @test  xp://web.unittest.CookieTest
  */
 class Cookie {
   private $name, $value;

--- a/src/main/php/web/Cookie.class.php
+++ b/src/main/php/web/Cookie.class.php
@@ -1,6 +1,7 @@
 <?php namespace web;
 
 use util\Date;
+use lang\IllegalArgumentException;
 
 /**
  * A HTTP/1.1 Cookie
@@ -26,6 +27,7 @@ class Cookie {
    *
    * @param  string $name
    * @param  string $value Pass `null` to remove the cookie
+   * @throws lang.IllegalArgumentException if value contains control characters or a semicolon
    */
   public function __construct($name, $value) {
     $this->name= $name;
@@ -33,6 +35,8 @@ class Cookie {
       $this->value= '';
       $this->expires= new Date(time() - 86400 * 365);
       $this->maxAge= 0;
+    } else if (preg_match('/[\x00-\x1F;]/', $value)) {
+      throw new IllegalArgumentException('Cookie values cannot contain control characters or semicolons');
     } else {
       $this->value= $value;
     }

--- a/src/main/php/web/Response.class.php
+++ b/src/main/php/web/Response.class.php
@@ -50,6 +50,16 @@ class Response {
     }
   }
 
+  /**
+   * Sets a cookie
+   *
+   * @param  web.Response $cookie
+   * @return void
+   */
+  public function cookie(Cookie $cookie) {
+    $this->headers['Set-Cookie'][]= $cookie->header();
+  }
+
   /** @return int */
   public function status() { return $this->status; }
 

--- a/src/main/php/xp/web/SAPI.class.php
+++ b/src/main/php/xp/web/SAPI.class.php
@@ -67,7 +67,7 @@ class SAPI extends \web\io\Output implements \web\io\Input {
     } else {
       header('HTTP/1.1 '.$status.' '.$message);
     }
-
+    unset($headers['Host'], $headers['Date']);
     foreach ($headers as $name => $header) {
       header($name.': '.array_shift($header));
       foreach ($header as $value) {

--- a/src/test/php/web/unittest/CookieTest.class.php
+++ b/src/test/php/web/unittest/CookieTest.class.php
@@ -1,0 +1,43 @@
+<?php namespace web\unittest;
+
+use web\Cookie;
+
+class CookieTest extends \unittest\TestCase {
+
+  #[@test]
+  public function can_create() {
+    new Cookie('name', 'value');
+  }
+
+  #[@test]
+  public function http_only_and_same_site_per_default() {
+    $this->assertEquals(
+      'name=value; SameSite=Lax; HttpOnly',
+      (new Cookie('name', 'value'))->header()
+    );
+  }
+
+  #[@test]
+  public function adding_path() {
+    $this->assertEquals(
+      'name=value; Path=/test; SameSite=Lax; HttpOnly',
+      (new Cookie('name', 'value'))->path('/test')->header()
+    );
+  }
+
+  #[@test]
+  public function setting_expiry() {
+    $this->assertEquals(
+      'name=value; Expires=Sat, 19 Nov 2016 16:29:22 GMT; SameSite=Lax; HttpOnly',
+      (new Cookie('name', 'value'))->expires('Sat, 19 Nov 2016 16:29:22 GMT')->header()
+    );
+  }
+
+  #[@test]
+  public function use_null_to_remove() {
+    $this->assertEquals(
+      'name=; Expires='.gmdate('D, d M Y H:i:s \G\M\T', time() - 86400 * 365).'; Max-Age=0; SameSite=Lax; HttpOnly',
+      (new Cookie('name', null))->header()
+    );
+  }
+}

--- a/src/test/php/web/unittest/CookieTest.class.php
+++ b/src/test/php/web/unittest/CookieTest.class.php
@@ -1,12 +1,23 @@
 <?php namespace web\unittest;
 
 use web\Cookie;
+use lang\IllegalArgumentException;
 
 class CookieTest extends \unittest\TestCase {
 
   #[@test]
   public function can_create() {
     new Cookie('name', 'value');
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function cannot_create_with_control_character() {
+    new Cookie('name', "\x00");
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function cannot_create_with_semicolon() {
+    new Cookie('name', ';');
   }
 
   #[@test]

--- a/src/test/php/web/unittest/CookieTest.class.php
+++ b/src/test/php/web/unittest/CookieTest.class.php
@@ -31,10 +31,34 @@ class CookieTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function removing_http_only() {
+    $this->assertEquals(
+      'name=value; SameSite=Lax',
+      (new Cookie('name', 'value'))->httpOnly(false)->header()
+    );
+  }
+
+  #[@test]
+  public function removing_same_site() {
+    $this->assertEquals(
+      'name=value; HttpOnly',
+      (new Cookie('name', 'value'))->sameSite(null)->header()
+    );
+  }
+
+  #[@test]
   public function adding_path() {
     $this->assertEquals(
       'name=value; Path=/test; SameSite=Lax; HttpOnly',
       (new Cookie('name', 'value'))->path('/test')->header()
+    );
+  }
+
+  #[@test]
+  public function adding_domain() {
+    $this->assertEquals(
+      'name=value; Domain=.example.com; SameSite=Lax; HttpOnly',
+      (new Cookie('name', 'value'))->domain('.example.com')->header()
     );
   }
 
@@ -74,6 +98,14 @@ class CookieTest extends \unittest\TestCase {
     $this->assertEquals(
       'name=; Expires='.gmdate('D, d M Y H:i:s \G\M\T', time() - 86400 * 365).'; Max-Age=0; SameSite=Lax; HttpOnly',
       (new Cookie('name', null))->header()
+    );
+  }
+
+  #[@test]
+  public function setting_secure() {
+    $this->assertEquals(
+      'name=value; SameSite=Lax; Secure; HttpOnly',
+      (new Cookie('name', 'value'))->secure()->header()
     );
   }
 }

--- a/src/test/php/web/unittest/CookieTest.class.php
+++ b/src/test/php/web/unittest/CookieTest.class.php
@@ -2,6 +2,8 @@
 
 use web\Cookie;
 use lang\IllegalArgumentException;
+use util\Date;
+use util\TimeSpan;
 
 class CookieTest extends \unittest\TestCase {
 
@@ -37,10 +39,33 @@ class CookieTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function setting_expiry() {
+  public function setting_max_age_to_zero() {
+    $this->assertEquals(
+      'name=value; Max-Age=0; SameSite=Lax; HttpOnly',
+      (new Cookie('name', 'value'))->maxAge(0)->header()
+    );
+  }
+
+  #[@test, @values([
+  #  3600,
+  #  new TimeSpan(3600)
+  #])]
+  public function setting_max_age($value) {
+    $this->assertEquals(
+      'name=value; Max-Age=3600; SameSite=Lax; HttpOnly',
+      (new Cookie('name', 'value'))->maxAge($value)->header()
+    );
+  }
+
+  #[@test, @values([
+  #  'Sat, 19 Nov 2016 16:29:22 GMT',
+  #  new Date('Sat, 19 Nov 2016 16:29:22 GMT'),
+  #  1479572962
+  #])]
+  public function setting_expiry($value) {
     $this->assertEquals(
       'name=value; Expires=Sat, 19 Nov 2016 16:29:22 GMT; SameSite=Lax; HttpOnly',
-      (new Cookie('name', 'value'))->expires('Sat, 19 Nov 2016 16:29:22 GMT')->header()
+      (new Cookie('name', 'value'))->expires($value)->header()
     );
   }
 

--- a/src/test/php/web/unittest/ResponseTest.class.php
+++ b/src/test/php/web/unittest/ResponseTest.class.php
@@ -87,18 +87,22 @@ class ResponseTest extends \unittest\TestCase {
 
   #[@test]
   public function cookie() {
+    $attr= '; SameSite=Lax; HttpOnly';
+
     $res= new Response(new TestOutput());
     $res->cookie(new Cookie('theme', 'light'));
-    $this->assertEquals(['Set-Cookie' => 'theme=light; HttpOnly'], $res->headers());
+    $this->assertEquals(['Set-Cookie' => 'theme=light'.$attr], $res->headers());
   }
 
   #[@test]
   public function cookies() {
+    $attr= '; SameSite=Lax; HttpOnly';
+
     $res= new Response(new TestOutput());
     $res->cookie(new Cookie('theme', 'Test'));
     $res->cookie((new Cookie('sessionToken', 'abc123'))->expires('Wed, 09 Jun 2021 10:18:14 GMT'));
     $this->assertEquals(
-      ['Set-Cookie' => ['theme=Test; HttpOnly', 'sessionToken=abc123; Expires=Wed, 09 Jun 2021 10:18:14 GMT; HttpOnly']],
+      ['Set-Cookie' => ['theme=Test'.$attr, 'sessionToken=abc123; Expires=Wed, 09 Jun 2021 10:18:14 GMT'.$attr]],
       $res->headers()
     );
   }

--- a/src/test/php/web/unittest/ResponseTest.class.php
+++ b/src/test/php/web/unittest/ResponseTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace web\unittest;
 
+use web\Cookie;
 use web\Response;
 use io\streams\MemoryInputStream;
 
@@ -82,6 +83,24 @@ class ResponseTest extends \unittest\TestCase {
     $res->header('Set-Cookie', 'theme=light', true);
     $res->header('Set-Cookie', 'sessionToken=abc123', true);
     $this->assertEquals(['Set-Cookie' => ['theme=light', 'sessionToken=abc123']], $res->headers());
+  }
+
+  #[@test]
+  public function cookie() {
+    $res= new Response(new TestOutput());
+    $res->cookie(new Cookie('theme', 'light'));
+    $this->assertEquals(['Set-Cookie' => 'theme=light; HttpOnly'], $res->headers());
+  }
+
+  #[@test]
+  public function cookies() {
+    $res= new Response(new TestOutput());
+    $res->cookie(new Cookie('theme', 'Test'));
+    $res->cookie((new Cookie('sessionToken', 'abc123'))->expires('Wed, 09 Jun 2021 10:18:14 GMT'));
+    $this->assertEquals(
+      ['Set-Cookie' => ['theme=Test; HttpOnly', 'sessionToken=abc123; Expires=Wed, 09 Jun 2021 10:18:14 GMT; HttpOnly']],
+      $res->headers()
+    );
   }
 
   #[@test, @values([


### PR DESCRIPTION
This pull request adds a `cookie()` method to the `Response` class. The HttpOnly attribute is set and the [SameSite attribute](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Alternate_CSRF_Defense:_SameSite_cookie_attribute) is transmitted with a [`Lax` value by default](https://chloe.re/2016/04/13/goodbye-csrf-samesite-to-the-rescue/).

### Set a cookie

This creates a session cookie by default. To extend its lifetime, use the `expires()` method.

```php
$res->cookie(new Cookie('name', 'value'));
```

### Remove a cookie

This sends an empty value, an expiry date a year ago and [`0` as max-age](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie).

```php
$res->cookie(new Cookie('name', null));
```

### Further options

```php
$res->cookie((new Cookie('name', 'value'))
  ->path('/')
  ->domain('.example.com')
  ->expires('tomorrow')      // or expires(new Date(...)), or expires(null) for session cookies
  ->secure()                 // or secure(false)
  ->httpOnly()               // or httpOnly(false)
  ->sameSite('Strict')       // or sameSite('Lax'), or sameSite(null) to remove
);
```

### Values

The only characters we do not allow inside values are control characters or semicolons. [RFC 6265, section 4.1.1](http://tools.ietf.org/html/rfc6265#section-4.1.1) states:

```
cookie-value      = *cookie-octet / ( DQUOTE *cookie-octet DQUOTE )
cookie-octet      = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
          ; US-ASCII characters excluding CTLs,
          ; whitespace DQUOTE, comma, semicolon,
          ; and backslash
```

We loosen this, tests with various browsers have concluded commas, double quotes, whitespace or backslashes are not of any problem

### Important note

SameSite is not yet supported by all browsers, see https://www.owasp.org/index.php/SameSite and https://caniuse.com/#feat=same-site-cookie-attribute; [vote for MS Edge support](https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/17140412-support-samesite-cookie-option)!