### PR TITLE
Rewrite

### DIFF
--- a/src/main/php/web/Request.class.php
+++ b/src/main/php/web/Request.class.php
@@ -47,6 +47,17 @@ class Request {
   }
 
   /**
+   * Rewrite request URI
+   *
+   * @param  string|util.URI $uri
+   * @return self
+   */
+  public function rewrite($uri) {
+    $this->uri= $this->uri->resolve($uri instanceof URI ? $uri : new URI($uri));
+    return $this;
+  }
+
+  /**
    * Encode a parameter's value to XP encoding
    *
    * @param  var $param

--- a/src/test/php/web/unittest/RequestTest.class.php
+++ b/src/test/php/web/unittest/RequestTest.class.php
@@ -2,6 +2,7 @@
 
 use web\Request;
 use io\streams\Streams;
+use util\URI;
 
 class RequestTest extends \unittest\TestCase {
   private static $CHUNKED = ['Transfer-Encoding' => 'chunked'];
@@ -33,7 +34,17 @@ class RequestTest extends \unittest\TestCase {
 
   #[@test]
   public function uri() {
-    $this->assertEquals('http://localhost/', (string)(new Request(new TestInput('GET', '/')))->uri());
+    $this->assertEquals(new URI('http://localhost/'), (new Request(new TestInput('GET', '/')))->uri());
+  }
+
+  #[@test, @values(['http://localhost/r', new URI('http://localhost/r')])]
+  public function rewrite_request($uri) {
+    $this->assertEquals(new URI('http://localhost/r'), (new Request(new TestInput('GET', '/')))->rewrite($uri)->uri());
+  }
+
+  #[@test, @values(['/r', new URI('/r')])]
+  public function rewrite_request_relative($uri) {
+    $this->assertEquals(new URI('http://localhost/r'), (new Request(new TestInput('GET', '/')))->rewrite($uri)->uri());
   }
 
   #[@test]


### PR DESCRIPTION
Add `web.Request::rewrite()` to implement rewriting request URIs

Example:
```php
// See http://httpd.apache.org/docs/2.4/mod/mod_proxy.html#x-headers
$rewrite= new class($base) implements Filter {
  private $base;

  public function __construct($base) {
    $this->base= $base;
  }

  public function filter($request, $response, $invocation) {
    if ($forwarded= $request->header('X-Forwarded-Host')) {
      $request->rewrite($request->uri()
        ->using()
        ->scheme($request->header('X-Forwarded-Proto') ?? 'https')
        ->host($forwarded)
        ->port($request->header('X-Forwarded-Port') ?? 443)
        ->path($this->base.$request->uri()->path())
        ->create()
      );
    }

    return $invocation->proceed($request, $response);
  }
};
```