### PR TITLE
Add Path class

### DIFF
--- a/src/main/php/web/handler/Paths.class.php
+++ b/src/main/php/web/handler/Paths.class.php
@@ -1,0 +1,100 @@
+<?php namespace web\handler;
+
+use io\Path;
+use io\Folder;
+use io\File;
+use lang\IllegalStateException;
+
+/**
+ * Paths can be used as constructor argument to the `FilesFrom` class
+ * which enables finer-granular control over the request URI to file
+ * resolution process.
+ *
+ * @test  xp://web.unittest.handler.PathsTest
+ */
+class Paths {
+  private $search= [];
+  private $strip= '/';
+  private $absent= null;
+  private $indexes= ['index.html'];
+  
+  /** @param (io.Path|io.Folder|string)... $paths */
+  public function __construct(... $paths) {
+    foreach ($paths as $path) {
+      if ($path instanceof Path) {
+        $this->search[]= $path;
+      } else if ($path instanceof Folder) {
+        $this->search[]= new Path($path);
+      } else {
+        $this->search[]= new Path($path);
+      }
+    }
+  }
+
+  /**
+   * Sets index documents. Defaults to "index.html"
+   *
+   * @param  string... $names Filenames without path!
+   * @return self
+   */
+  public function indexes(...$names) {
+    $this->indexes= $names;
+    return $this;
+  }
+
+  /**
+   * Sets prefix to strip
+   *
+   * @param  string $prefix
+   * @return self
+   */
+  public function stripping($prefix) {
+    $this->strip= rtrim($prefix, '/').'/';
+    return $this;
+  }
+
+  /**
+   * Sets default file to serve
+   *
+   * @param  io.File|io.Path|string|function(string): File $arg
+   * @return self
+   */
+  public function absent($arg) {
+    if ($arg instanceof \Closure) {
+      $this->absent= $arg;
+    } else {
+      $file= $arg instanceof File ? $arg : new File($arg);
+      $this->absent= function($uri) use($file) { return $file; };
+    }
+    return $this;
+  }
+
+  /**
+   * Resolves a URI
+   *
+   * @param  string $uri
+   * @return io.File $file
+   */
+  public function resolve($uri) {
+    $prefix= strlen($this->strip);
+    if (0 !== strncmp($uri, $this->strip, $prefix)) {
+      throw new IllegalStateException('URI '.$uri.' does not contain prefix '.$this->strip);
+    }
+
+    $path= substr($uri, $prefix);
+    foreach ($this->search as $search) {
+      $target= new Path($search, $path);
+      if ($target->isFolder()) {
+        foreach ($this->indexes as $index) {
+          $file= new File($target, $index);
+          if ($file->exists()) return $file;
+        }
+      } else {
+        $file= $target->asFile();
+        if ($file->exists()) return $file;
+      }
+    }
+
+    return null === $this->absent ? null : $this->absent->__invoke($uri);
+  }
+}

--- a/src/main/php/web/handler/Paths.class.php
+++ b/src/main/php/web/handler/Paths.class.php
@@ -48,7 +48,7 @@ class Paths {
    * @param  string $prefix
    * @return self
    */
-  public function stripping($prefix) {
+  public function strip($prefix) {
     $this->strip= rtrim($prefix, '/').'/';
     return $this;
   }

--- a/src/test/php/web/unittest/handler/PathsTest.class.php
+++ b/src/test/php/web/unittest/handler/PathsTest.class.php
@@ -1,0 +1,123 @@
+<?php namespace web\unittest\handler;
+
+use web\handler\Paths;
+use io\File;
+use io\FileUtil;
+use io\Folder;
+use io\Path;
+use lang\Environment;
+use lang\IllegalStateException;
+
+class PathsTest extends \unittest\TestCase {
+  private $cleanup= [];
+
+  /**
+   * Creates files inside a temporary directory and returns its path
+   *
+   * @param  [:string] $files
+   * @return io.Path
+   */
+  private function pathWith($files) {
+    $folder= new Folder(Environment::tempDir(), uniqid($this->name, true));
+    $folder->create(0777);
+    foreach ($files as $name => $contents) {
+      FileUtil::setContents(new File($folder, $name), $contents);
+    }
+    $this->cleanup[]= $folder;
+    return new Path($folder);
+  }
+
+  /** @return void */
+  public function tearDown() {
+    foreach ($this->cleanup as $folder) {
+      $folder->exists() && $folder->unlink();
+    }
+  }
+
+  #[@test]
+  public function can_create() {
+    new Paths();
+  }
+
+  #[@test]
+  public function can_create_with_path() {
+    new Paths($this->pathWith([]));
+  }
+
+  #[@test]
+  public function resolve_existant_file() {
+    $path= $this->pathWith(['test.html' => 'Test']);
+    $this->assertEquals(new File($path, 'test.html'), (new Paths($path))->resolve('/test.html'));
+  }
+
+  #[@test]
+  public function resolve_non_existant_file() {
+    $path= $this->pathWith(['test.html' => 'Test']);
+    $this->assertNull((new Paths($path))->resolve('/non-existant.html'));
+  }
+
+  #[@test]
+  public function absent_file_used_for_non_existant_file() {
+    $file= new File($this->pathWith(['error404.html' => 'Test']), 'error404.html');
+    $this->assertEquals($file, (new Paths())
+      ->absent($file)
+      ->resolve('/')
+    );
+  }
+
+  #[@test]
+  public function absent_function_used_for_non_existant_file() {
+    $file= new File($this->pathWith(['error404.html' => 'Test']), 'error404.html');
+    $this->assertEquals($file, (new Paths())
+      ->absent(function($uri) use($file) { return $file; })
+      ->resolve('/')
+    );
+  }
+
+  #[@test]
+  public function index_html() {
+    $path= $this->pathWith(['index.html' => 'Test']);
+    $this->assertEquals(new File($path, 'index.html'), (new Paths($path))->resolve('/'));
+  }
+
+  #[@test]
+  public function index_html_variation() {
+    $path= $this->pathWith(['index.htm' => 'Test']);
+    $this->assertEquals(
+      new File($path, 'index.htm'),
+      (new Paths($path))->indexes('index.html', 'index.htm')->resolve('/')
+    );
+  }
+
+  #[@test]
+  public function search_path_used() {
+    $paths= [
+      $this->pathWith(['a.html' => 'Path 0']),
+      $this->pathWith(['b.html' => 'Path 1'])
+    ];
+    $this->assertEquals(new File($paths[1], 'b.html'), (new Paths(...$paths))->resolve('/b.html'));
+  }
+
+  #[@test]
+  public function first_occurrence_from_search_path_picked() {
+    $paths= [
+      $this->pathWith(['b.html' => 'Path 0']),
+      $this->pathWith(['b.html' => 'Path 1'])
+    ];
+    $this->assertEquals(new File($paths[0], 'b.html'), (new Paths(...$paths))->resolve('/b.html'));
+  }
+
+  #[@test, @values(['/static', '/static/'])]
+  public function stripping($prefix) {
+    $path= $this->pathWith(['a.html' => 'Test']);
+    $this->assertEquals(new File($path, 'a.html'), (new Paths($path))
+      ->stripping($prefix)
+      ->resolve('/static/a.html')
+    );
+  }
+
+  #[@test, @expect(IllegalStateException::class)]
+  public function error_raised_when_prefix_not_in_request() {
+    (new Paths())->stripping('/static')->resolve('/index.html');
+  }
+}

--- a/src/test/php/web/unittest/handler/PathsTest.class.php
+++ b/src/test/php/web/unittest/handler/PathsTest.class.php
@@ -108,16 +108,16 @@ class PathsTest extends \unittest\TestCase {
   }
 
   #[@test, @values(['/static', '/static/'])]
-  public function stripping($prefix) {
+  public function strip($prefix) {
     $path= $this->pathWith(['a.html' => 'Test']);
     $this->assertEquals(new File($path, 'a.html'), (new Paths($path))
-      ->stripping($prefix)
+      ->strip($prefix)
       ->resolve('/static/a.html')
     );
   }
 
   #[@test, @expect(IllegalStateException::class)]
   public function error_raised_when_prefix_not_in_request() {
-    (new Paths())->stripping('/static')->resolve('/index.html');
+    (new Paths())->strip('/static')->resolve('/index.html');
   }
 }


### PR DESCRIPTION
Paths can be used as constructor argument to the `FilesFrom` class which enables finer-granular control over the request URI to file resolution process.

## API

```php
public class web.handler.Paths {
  public __construct((io.Path|io.Folder|string)... $paths)

  public web.handler.Paths indexes(string... $names)
  public web.handler.Paths strip(string $prefix)
  public web.handler.Paths absent(io.File|io.Path|string|(function(string): io.File) $arg)
  public io.File resolve(util.URI $uri)
}
```

## Example

```php
$paths= (new Paths($webroot, '/var/www/icons'))
  ->strip('/static')
  ->indexes('index.html', 'index.htm')
  ->absent(new File($webroot, 'error404.html'))
;

return ['/static' => new FilesFrom($paths)];
```