### PR TITLE
Dispatching

### DIFF
--- a/src/main/php/web/Dispatch.class.php
+++ b/src/main/php/web/Dispatch.class.php
@@ -1,0 +1,29 @@
+<?php namespace web;
+
+use util\URI;
+
+/**
+ * Dispatches a request; performing an internal redirect.
+ * 
+ * Return instances of this class from a handler *before* the response
+ * has been flushed, as follows:
+ *
+ * ```php
+ * function($req, $res) {
+ *   return $req->dispatch('/home');
+ * }
+ * ```
+ *
+ * @see   xp://web.Request#dispatch
+ */
+class Dispatch {
+  private $uri;
+
+  /** @param util.URI|string $uri */
+  public function __construct($uri) {
+    $this->uri= $uri instanceof URI ? $uri : new URI($uri);
+  }
+
+  /** @return util.URI */
+  public function uri() { return $this->uri; }
+}

--- a/src/main/php/web/Request.class.php
+++ b/src/main/php/web/Request.class.php
@@ -250,6 +250,14 @@ class Request implements Value {
   }
 
   /**
+   * Dispatches request
+   *
+   * @param  string|util.URI $uri
+   * @return web.Dispatch
+   */
+  public function dispatch($uri) { return new Dispatch($uri); }
+
+  /**
    * Gets a cookie by name
    *
    * @param  string $name

--- a/src/main/php/web/Routing.class.php
+++ b/src/main/php/web/Routing.class.php
@@ -138,6 +138,13 @@ class Routing {
    * @return var
    */
   public function service($request, $response) {
-    return $this->route($request)->handle($request, $response);
+    do {
+      $result= $this->route($request)->handle($request, $response);
+      if ($result instanceof Dispatch) {
+        $request->rewrite($result->uri());
+        continue;
+      }
+      return $result;
+    } while (true);
   }
 }

--- a/src/main/php/web/Routing.class.php
+++ b/src/main/php/web/Routing.class.php
@@ -138,10 +138,15 @@ class Routing {
    * @return var
    */
   public function service($request, $response) {
+    $seen= [];
     do {
       $result= $this->route($request)->handle($request, $response);
       if ($result instanceof Dispatch) {
+        $seen[$request->uri()->hashCode()]= true;
         $request->rewrite($result->uri());
+        if (isset($seen[$request->uri()->hashCode()])) {
+          throw new Error(508, 'Internal redirect loop caused by dispatch to '.$result->uri());
+        }
         continue;
       }
       return $result;

--- a/src/test/php/web/unittest/ApplicationTest.class.php
+++ b/src/test/php/web/unittest/ApplicationTest.class.php
@@ -2,6 +2,7 @@
 
 use web\Application;
 use web\Environment;
+use web\Error;
 use web\Handler;
 use web\Request;
 use web\Response;
@@ -113,6 +114,34 @@ class ApplicationTest extends \unittest\TestCase {
         },
         '/' => function($request, $response) {
           return $request->dispatch('/home');
+        },
+      ];
+    });
+  }
+
+  #[@test, @expect(class= Error::class, withMessage= '/Internal redirect loop/')]
+  public function dispatch_request_to_self_causes_error() {
+    $this->assertHandled($handled, function() use(&$handled) {
+      return [
+        '/' => function($request, $response) {
+          return $request->dispatch('/');
+        },
+      ];
+    });
+  }
+
+  #[@test, @expect(class= Error::class, withMessage= '/Internal redirect loop/')]
+  public function dispatch_request_ping_pong_causes_error() {
+    $this->assertHandled($handled, function() use(&$handled) {
+      return [
+        '/home' => function($request, $response) {
+          return $request->dispatch('/');
+        },
+        '/user' => function($request, $response) {
+          return $request->dispatch('/home');
+        },
+        '/' => function($request, $response) {
+          return $request->dispatch('/user');
         },
       ];
     });

--- a/src/test/php/web/unittest/ApplicationTest.class.php
+++ b/src/test/php/web/unittest/ApplicationTest.class.php
@@ -103,4 +103,18 @@ class ApplicationTest extends \unittest\TestCase {
       ]);
     });
   }
+
+  #[@test]
+  public function dispatch_request() {
+    $this->assertHandled($handled, function() use(&$handled) {
+      return [
+        '/home' => function($request, $response) use(&$handled) {
+          $handled[]= [$request, $response];
+        },
+        '/' => function($request, $response) {
+          return $request->dispatch('/home');
+        },
+      ];
+    });
+  }
 }


### PR DESCRIPTION
This pull request adds internal redirects; which in contrast to external redirects, do not come with the protocol overhead.

```php
use web\Application;

class Site extends Application {

  public function routes() {
    return [
      '/home' => function($request, $response) {
        // Home page
      },
      '/' => function($request, $response) {
        // Routes are re-evaluated as if user had called /home
        return $request->dispatch('/home');
      },
    ];
  }
}
```