### PR TITLE
Add BehindProxy filter

### DIFF
--- a/src/main/php/web/filters/BehindProxy.class.php
+++ b/src/main/php/web/filters/BehindProxy.class.php
@@ -1,0 +1,90 @@
+<?php namespace web\filters;
+
+use web\Filter;
+
+/**
+ * Rewrites request URI if behind a reverse proxy
+ *
+ * A typical scenario might look like this:
+ * ```
+ * https://intranet.example.com/app (Apache) => {
+ *   http://app.intranet-services01.lan:8080 (XP Web)
+ *   http://app.intranet-services02.lan:8080 (XP Web)
+ * }
+ * ```
+ * - Apache takes care of balancing and SSL
+ * - We route /app to a subdomain
+ *
+ * In this case, we'll need to reconstruct the original, outward-facing request
+ * URL by using proxy headers such as `X-Forwarded-Host` and by prefixing its
+ * path with "/app".
+ *
+ * @see  https://en.wikipedia.org/wiki/Reverse_proxy
+ * @see  http://httpd.apache.org/docs/2.4/mod/mod_proxy.html#x-headers
+ * @see  https://www.nginx.com/resources/wiki/start/topics/examples/forwarded/
+ * @see  https://stackoverflow.com/questions/19084340/real-life-usage-of-the-x-forwarded-host-header
+ * @test xp://web.unittest.filters.BehindProxyTest
+ */
+class BehindProxy implements Filter {
+  private $path= null;
+  private $protocol= null;
+
+  /**
+   * Force the use of a given protocol
+   *
+   * @param  string $protocol One of "http", "https"
+   * @return self
+   */
+  public function using($protocol) {
+    $this->protocol= $protocol;
+    return $this;
+  }
+
+  /**
+   * Prefix paths with a given base
+   *
+   * @param  string $base
+   * @return self
+   */
+  public function prefixed($base) {
+    $prefix= rtrim($base, '/');
+    $this->path= function($path) use($prefix) { return $prefix.$path; };
+    return $this;
+  }
+
+  /**
+   * Strip paths of a given base
+   *
+   * @param  string $base
+   * @return self
+   */
+  public function stripping($base) {
+    $strip= '#^'.rtrim($base, '/').'#';
+    $this->path= function($path) use($strip) { return preg_replace($strip, '', $path) ?: '/'; };
+    return $this;
+  }
+
+  /**
+   * Applies filter
+   *
+   * @param  web.Request $request
+   * @param  web.Response $response
+   * @param  web.filters.Invocation $invocation
+   * @return var
+   */
+  public function filter($request, $response, $invocation) {
+    $uri= $request->uri();
+    if ($forwarded= $request->header('X-Forwarded-Host')) {
+      $rewrite= $this->path;
+      $request->rewrite($uri->using()
+        ->host($forwarded)
+        ->scheme($this->protocol ?: $request->header('X-Forwarded-Proto', 'https'))
+        ->port($request->header('X-Forwarded-Port', null))
+        ->path($rewrite ? $rewrite($uri->path()) : $uri->path())
+        ->create()
+      );
+    }
+
+    return $invocation->proceed($request, $response);
+  }
+}

--- a/src/main/php/web/filters/BehindProxy.class.php
+++ b/src/main/php/web/filters/BehindProxy.class.php
@@ -5,20 +5,7 @@ use web\Filter;
 /**
  * Rewrites request URI if behind a reverse proxy
  *
- * A typical scenario might look like this:
- * ```
- * https://intranet.example.com/app (Apache) => {
- *   http://app.intranet-services01.lan:8080 (XP Web)
- *   http://app.intranet-services02.lan:8080 (XP Web)
- * }
- * ```
- * - Apache takes care of balancing and SSL
- * - We route /app to a subdomain
- *
- * In this case, we'll need to reconstruct the original, outward-facing request
- * URL by using proxy headers such as `X-Forwarded-Host` and by prefixing its
- * path with "/app".
- *
+ * @see  https://github.com/xp-forge/web/pull/40
  * @see  https://en.wikipedia.org/wiki/Reverse_proxy
  * @see  http://httpd.apache.org/docs/2.4/mod/mod_proxy.html#x-headers
  * @see  https://www.nginx.com/resources/wiki/start/topics/examples/forwarded/

--- a/src/test/php/web/unittest/filters/BehindProxyTest.class.php
+++ b/src/test/php/web/unittest/filters/BehindProxyTest.class.php
@@ -1,0 +1,102 @@
+<?php namespace web\unittest\filters;
+
+use unittest\TestCase;
+use web\Filter;
+use web\filters\BehindProxy;
+use web\filters\Invocation;
+use web\io\TestInput;
+use web\io\TestOutput;
+use web\Request;
+use web\Response;
+
+class BehindProxyTest extends TestCase {
+
+  #[@test]
+  public function can_create() {
+    new BehindProxy();
+  }
+
+  #[@test]
+  public function no_rewriting_performed_by_default() {
+    $filter= new BehindProxy();
+    $filter->filter(
+      new Request(new TestInput('GET', '/')),
+      new Response(new TestOutput()),
+      new Invocation(function($req, $res) use(&$request) { $request= $req; }, [])
+    );
+
+    $this->assertEquals('http://localhost/', (string)$request->uri());
+  }
+
+  #[@test]
+  public function honours_forwarded_host_header_and_defaults_to_https() {
+    $filter= new BehindProxy();
+    $filter->filter(
+      new Request(new TestInput('GET', '/', ['X-Forwarded-Host' => 'example.com'])),
+      new Response(new TestOutput()),
+      new Invocation(function($req, $res) use(&$request) { $request= $req; }, [])
+    );
+
+    $this->assertEquals('https://example.com/', (string)$request->uri());
+  }
+
+  #[@test]
+  public function honours_forwarded_proto_header() {
+    $filter= new BehindProxy();
+    $filter->filter(
+      new Request(new TestInput('GET', '/', ['X-Forwarded-Host' => 'example.com', 'X-Forwarded-Proto' => 'http'])),
+      new Response(new TestOutput()),
+      new Invocation(function($req, $res) use(&$request) { $request= $req; }, [])
+    );
+
+    $this->assertEquals('http://example.com/', (string)$request->uri());
+  }
+
+  #[@test]
+  public function can_force_https_via_using() {
+    $filter= (new BehindProxy())->using('https');
+    $filter->filter(
+      new Request(new TestInput('GET', '/', ['X-Forwarded-Host' => 'example.com', 'X-Forwarded-Proto' => 'http'])),
+      new Response(new TestOutput()),
+      new Invocation(function($req, $res) use(&$request) { $request= $req; }, [])
+    );
+
+    $this->assertEquals('https://example.com/', (string)$request->uri());
+  }
+
+  #[@test, @values(['/app', '/app/'])]
+  public function prefixed_base($base) {
+    $filter= (new BehindProxy())->prefixed($base);
+    $filter->filter(
+      new Request(new TestInput('GET', '/', ['X-Forwarded-Host' => 'example.com'])),
+      new Response(new TestOutput()),
+      new Invocation(function($req, $res) use(&$request) { $request= $req; }, [])
+    );
+
+    $this->assertEquals('https://example.com/app/', (string)$request->uri());
+  }
+
+  #[@test, @values(['/app', '/app/'])]
+  public function stripping_base($base) {
+    $filter= (new BehindProxy())->stripping($base);
+    $filter->filter(
+      new Request(new TestInput('GET', '/app/', ['X-Forwarded-Host' => 'example.com'])),
+      new Response(new TestOutput()),
+      new Invocation(function($req, $res) use(&$request) { $request= $req; }, [])
+    );
+
+    $this->assertEquals('https://example.com/', (string)$request->uri());
+  }
+
+  #[@test, @values(['/app', '/app/'])]
+  public function stripping_base_without_trailing_slash($base) {
+    $filter= (new BehindProxy())->stripping($base);
+    $filter->filter(
+      new Request(new TestInput('GET', '/app', ['X-Forwarded-Host' => 'example.com'])),
+      new Response(new TestOutput()),
+      new Invocation(function($req, $res) use(&$request) { $request= $req; }, [])
+    );
+
+    $this->assertEquals('https://example.com/', (string)$request->uri());
+  }
+}

--- a/src/test/php/web/unittest/filters/BehindProxyTest.class.php
+++ b/src/test/php/web/unittest/filters/BehindProxyTest.class.php
@@ -126,4 +126,15 @@ class BehindProxyTest extends TestCase {
 
     $this->assertEquals('https://example.com/', (string)$request->uri());
   }
+
+  #[@test]
+  public function only_uses_last_host() {
+    (new BehindProxy(self::PROXY_ADDRESS))->filter(
+      $this->proxyRequest('/', ['X-Forwarded-Host' => 'evil.com, example.com']),
+      new Response(new TestOutput()),
+      new Invocation(function($req, $res) use(&$request) { $request= $req; }, [])
+    );
+
+    $this->assertEquals('https://example.com/', (string)$request->uri());
+  }
 }

--- a/src/test/php/web/unittest/filters/BehindProxyTest.class.php
+++ b/src/test/php/web/unittest/filters/BehindProxyTest.class.php
@@ -107,7 +107,7 @@ class BehindProxyTest extends TestCase {
 
   #[@test, @values(['/app', '/app/'])]
   public function stripping_base($base) {
-    ((new BehindProxy(self::PROXY_ADDRESS))->stripping($base))->filter(
+    (new BehindProxy(self::PROXY_ADDRESS))->stripping($base)->filter(
       $this->proxyRequest('/app/', ['X-Forwarded-Host' => 'example.com']),
       new Response(new TestOutput()),
       new Invocation(function($req, $res) use(&$request) { $request= $req; }, [])
@@ -118,7 +118,7 @@ class BehindProxyTest extends TestCase {
 
   #[@test, @values(['/app', '/app/'])]
   public function stripping_base_without_trailing_slash($base) {
-    ((new BehindProxy(self::PROXY_ADDRESS))->stripping($base))->filter(
+    (new BehindProxy(self::PROXY_ADDRESS))->stripping($base)->filter(
       $this->proxyRequest('/app', ['X-Forwarded-Host' => 'example.com']),
       new Response(new TestOutput()),
       new Invocation(function($req, $res) use(&$request) { $request= $req; }, [])


### PR DESCRIPTION
## Rewrite request URI if behind a reverse proxy

### A) Path to subdomain

One scenario might look like this:
```
https://intranet.example.com/app (Apache) => {
  http://app.intranet-services01.lan:8080 (XP Web)
  http://app.intranet-services02.lan:8080 (XP Web)
}
```
- Apache takes care of balancing and SSL
- We route /app to a subdomain

In this case, we'll need to reconstruct the original, outward-facing request URL by using proxy headers such as `X-Forwarded-Host` and by prefixing it path with "/app":

```php
$filter= (new BehindProxy())->using('https')->prefixed('/app');
```

* * *

### B) Subdomain to path

Another scenario might use a different mapping

```
https://app.intranet.example.com (Apache) => {
  http://intranet-services01.lan:8080/app (XP Web)
  http://intranet-services02.lan:8080/app (XP Web)
}
```
- Again, Apache takes care of balancing and SSL
- However, we route subdomains to a path

Here, we'll need to remove the "/app" prefix from the URL in order to reconstruct the URL the user accessing app.intranet.example.com sees

```php
$filter= (new BehindProxy())->using('https')->stripping('/app');
```

* * * 

* The `using('https')` call is not mandatory, the implementation will use the `X-Forwarded-Proto`-header instead, and fall back to "https" if it's not present. 