### PR TITLE
Add BehindProxy filter

### DIFF
--- a/src/main/php/web/filters/BehindProxy.class.php
+++ b/src/main/php/web/filters/BehindProxy.class.php
@@ -1,0 +1,44 @@
+<?php namespace web\filters;
+
+use web\Filter;
+use util\URI;
+use lang\IllegalArgumentException;
+
+/**
+ * Rewrites URLs if behind a proxy
+ *
+ * @test  xp://web.unittest.filters.BehindProxyTest
+ */
+class BehindProxy implements Filter {
+
+  /**
+   * Creates a new instance given a map of the front-facing URL to the local path
+   *
+   * @param  [:string] $mapping
+   */
+  public function __construct($mapping) {
+    if (1 !== sizeof($mapping)) {
+      throw new IllegalArgumentException('Expected a map in the form ["http://remote.url/" => "/local.path"]');
+    }
+
+    $this->remote= new URI(key($mapping));
+    $this->replace= '#^'.rtrim(preg_quote(current($mapping), '#'), '/').'/#';
+  }
+
+  /**
+   * Applies filter
+   *
+   * @param  web.Request $request
+   * @param  web.Response $response
+   * @param  web.filters.Invocation $invocation
+   * @return var
+   */
+  public function filter($request, $response, $invocation) {
+    $uri= $this->remote->using()
+      ->path(preg_replace($this->replace, $this->remote->path(), $request->uri()->path()))
+      ->create()
+    ;
+
+    return $invocation->proceed($request->rewrite($uri), $response);
+  }
+}

--- a/src/test/php/web/unittest/filters/BehindProxyTest.class.php
+++ b/src/test/php/web/unittest/filters/BehindProxyTest.class.php
@@ -1,0 +1,53 @@
+<?php namespace web\unittest\filters;
+
+use unittest\TestCase;
+use web\filters\BehindProxy;
+use web\filters\Invocation;
+use web\io\TestInput;
+use web\io\TestOutput;
+use web\Request;
+use web\Response;
+
+class BehindProxyTest extends TestCase {
+
+  #[@test]
+  public function can_create() {
+    new BehindProxy(['http://remote' => '/']);
+  }
+
+  #[@test, @values(['/', '/path', '/path/', '/path/index.html'])]
+  public function rewrite_subdomain_to_base($path) {
+    $request= new Request(new TestInput('GET', $path));
+    $fixture= new BehindProxy(['https://service.example.com/' => '/']);
+    $fixture->filter($request, new Response(new TestOutput()), new Invocation(function($req, $res) { }));
+
+    $this->assertEquals('https://service.example.com'.$path, (string)$request->uri());
+  }
+
+  #[@test, @values(['/', '/path', '/path/', '/path/index.html'])]
+  public function rewrite_path_to_base($path) {
+    $request= new Request(new TestInput('GET', $path));
+    $fixture= new BehindProxy(['https://example.com/service/' => '/']);
+    $fixture->filter($request, new Response(new TestOutput()), new Invocation(function($req, $res) { }));
+
+    $this->assertEquals('https://example.com/service'.$path, (string)$request->uri());
+  }
+
+  #[@test, @values(['/', '/path', '/path/', '/path/index.html'])]
+  public function rewrite_subdomain_to_path($path) {
+    $request= new Request(new TestInput('GET', '/service'.$path));
+    $fixture= new BehindProxy(['https://service.example.com/' => '/service']);
+    $fixture->filter($request, new Response(new TestOutput()), new Invocation(function($req, $res) { }));
+
+    $this->assertEquals('https://service.example.com'.$path, (string)$request->uri());
+  }
+
+  #[@test, @values(['/', '/path', '/path/', '/path/index.html'])]
+  public function rewrite_path_to_path($path) {
+    $request= new Request(new TestInput('GET', '/service'.$path));
+    $fixture= new BehindProxy(['https://example.com/service/' => '/service']);
+    $fixture->filter($request, new Response(new TestOutput()), new Invocation(function($req, $res) { }));
+
+    $this->assertEquals('https://example.com/service'.$path, (string)$request->uri());
+  }
+}


### PR DESCRIPTION
# Rewrite request URI if behind a reverse proxy

On Apache:

```apache
<VirtualHost service.example.com:443>
  ProxyPass / http://service.example-backend.lan:8080/
</VirtualHost>
```

In your service:

```php
$filter= new BehindProxy(['https://service.example.com/' => '/']);
```

See also #40 - especially the research and discussion as to why relying on a complicated mix of `X-Forwarded-*` headers and a trusted proxy list seems to be total overkill; hence this simpler solution.