### PR TITLE
Ability to pass body as map to web.io.TestInput

### DIFF
--- a/src/main/php/web/io/TestInput.class.php
+++ b/src/main/php/web/io/TestInput.class.php
@@ -14,13 +14,19 @@ class TestInput implements Input {
    * @param  string $method
    * @param  string $uri
    * @param  [:string] $headers
-   * @param  string $body
+   * @param  string|[:string] $body
    */
   public function __construct($method, $uri, $headers= [], $body= '') {
     $this->method= $method;
     $this->uri= $uri;
     $this->headers= $headers;
-    $this->body= $body;
+
+    if (is_array($body)) {
+      $this->body= http_build_query($body);
+      $this->headers+= ['Content-Type' => 'application/x-www-form-urlencoded', 'Content-Length' => strlen($this->body)];
+    } else {
+      $this->body= $body;
+    }
   }
 
   /** @return string */

--- a/src/test/php/web/unittest/io/TestInputTest.class.php
+++ b/src/test/php/web/unittest/io/TestInputTest.class.php
@@ -63,4 +63,14 @@ class TestInputTest extends TestCase {
     $this->assertEquals('line 2', $fixture->readLine());
     $this->assertNull($fixture->readLine());
   }
+
+  #[@test]
+  public function body_can_be_passed_as_array() {
+    $fixture= new TestInput('GET', '/', [], ['key' => 'value']);
+    $this->assertEquals('key=value', $fixture->read());
+    $this->assertEquals(
+      ['Content-Type' => 'application/x-www-form-urlencoded', 'Content-Length' => 9],
+      $fixture->headers()
+    );
+  }
 }


### PR DESCRIPTION
Simplifies unittests as follows:

### Before

```php
$body= 'key=value';
$headers= [
  'Content-Type'   => 'application/x-www-form-urlencoded',
  'Content-Length' => strlen($body)
];

new TestInput('POST', '/', $headers, $body);
```

### After

```php
new TestInput('POST', '/', [], ['key' => 'value']);
```