### PR TITLE
Calculate content length of given body

### DIFF
--- a/src/main/php/web/io/TestInput.class.php
+++ b/src/main/php/web/io/TestInput.class.php
@@ -23,9 +23,13 @@ class TestInput implements Input {
 
     if (is_array($body)) {
       $this->body= http_build_query($body);
-      $this->headers+= ['Content-Type' => 'application/x-www-form-urlencoded', 'Content-Length' => strlen($this->body)];
+      $this->headers+= ['Content-Type' => 'application/x-www-form-urlencoded'];
     } else {
       $this->body= $body;
+    }
+
+    if (strlen($this->body) > 0 && !isset($this->headers['Transfer-Encoding'])) {
+      $this->headers+= ['Content-Length' => strlen($this->body)];
     }
   }
 

--- a/src/test/php/web/unittest/io/TestInputTest.class.php
+++ b/src/test/php/web/unittest/io/TestInputTest.class.php
@@ -65,11 +65,29 @@ class TestInputTest extends TestCase {
   }
 
   #[@test]
+  public function content_length_calculated() {
+    $fixture= new TestInput('GET', '/', ['Content-Type' => 'text/plain'], 'Test');
+    $this->assertEquals(
+      ['Content-Type' => 'text/plain', 'Content-Length' => 4],
+      $fixture->headers()
+    );
+  }
+
+  #[@test]
+  public function content_length_not_calculated_when_chunked() {
+    $fixture= new TestInput('GET', '/', ['Transfer-Encoding' => 'chunked'], "4\r\nTest\r\n0\r\n\r\n");
+    $this->assertEquals(
+      ['Transfer-Encoding' => 'chunked'],
+      $fixture->headers()
+    );
+  }
+
+  #[@test]
   public function body_can_be_passed_as_array() {
-    $fixture= new TestInput('GET', '/', [], ['key' => 'value']);
+    $fixture= new TestInput('GET', '/', ['Accept' => '*/*'], ['key' => 'value']);
     $this->assertEquals('key=value', $fixture->read());
     $this->assertEquals(
-      ['Content-Type' => 'application/x-www-form-urlencoded', 'Content-Length' => 9],
+      ['Accept' => '*/*', 'Content-Type' => 'application/x-www-form-urlencoded', 'Content-Length' => 9],
       $fixture->headers()
     );
   }


### PR DESCRIPTION
Simplifies testing code

### Before

```php
$body= 'Test';
new TestInput('POST', '/', ['Content-Length' =>strlen($body)], $body);
```

### Atfer

```php
new TestInput('POST', '/', [], 'Test');
```