### PR TITLE
TestOutput constructors

### DIFF
--- a/src/main/php/web/io/TestOutput.class.php
+++ b/src/main/php/web/io/TestOutput.class.php
@@ -38,6 +38,7 @@ class TestOutput extends Output {
   /**
    * Use stream class, which defaults to `WriteChunks`
    *
+   * @deprecated Use constructor instead
    * @param  string|lang.XPClass $stream
    * @return self
    */

--- a/src/main/php/web/io/TestOutput.class.php
+++ b/src/main/php/web/io/TestOutput.class.php
@@ -8,13 +8,32 @@ use lang\XPClass;
  * @test  xp://web.unittest.io.TestOutputTest
  */
 class TestOutput extends Output {
-  private $bytes;
-  private $stream;
+  private $bytes, $stream;
 
-  /** Create a new Test Output */
-  public function __construct() {
-    $this->stream= new XPClass(WriteChunks::class);
+  /** @param string|lang.XPClass $stream */
+  public function __construct($stream= null) {
+    if (null === $stream) {
+      $this->stream= new XPClass(WriteChunks::class);
+    } else if ($stream instanceof XPClass) {
+      $this->stream= $stream;
+    } else {
+      $this->stream= XPClass::forName($stream);
+    }
   }
+
+  /**
+   * Creates a new buffered test output
+   *
+   * @return self
+   */
+  public static function buffered() { return new self(Buffered::class); }
+
+  /**
+   * Creates a new chunked test output
+   *
+   * @return self
+   */
+  public static function chunked() { return new self(WriteChunks::class); }
 
   /**
    * Use stream class, which defaults to `WriteChunks`

--- a/src/test/php/web/unittest/io/TestOutputTest.class.php
+++ b/src/test/php/web/unittest/io/TestOutputTest.class.php
@@ -67,4 +67,32 @@ class TestOutputTest extends TestCase {
       $fixture->bytes()
     );
   }
+
+  #[@test]
+  public function chunked_stream_via_constructor() {
+    $fixture= TestOutput::chunked();
+    with ($fixture->stream(), function($stream) {
+      $stream->begin(200, 'OK', []);
+      $stream->write('Hello');
+      $stream->write('Test');
+    });
+    $this->assertEquals(
+      "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n9\r\nHelloTest\r\n0\r\n\r\n",
+      $fixture->bytes()
+    );
+  }
+
+  #[@test]
+  public function buffered_stream_via_constructor() {
+    $fixture= TestOutput::buffered();
+    with ($fixture->stream(), function($stream) {
+      $stream->begin(200, 'OK', []);
+      $stream->write('Hello');
+      $stream->write('Test');
+    });
+    $this->assertEquals(
+      "HTTP/1.1 200 OK\r\nContent-Length: 9\r\n\r\nHelloTest",
+      $fixture->bytes()
+    );
+  }
 }

--- a/src/test/php/web/unittest/io/TestOutputTest.class.php
+++ b/src/test/php/web/unittest/io/TestOutputTest.class.php
@@ -56,7 +56,7 @@ class TestOutputTest extends TestCase {
 
   #[@test]
   public function buffered_stream() {
-    $fixture= (new TestOutput())->using(Buffered::class);
+    $fixture= new TestOutput(Buffered::class);
     with ($fixture->stream(), function($stream) {
       $stream->begin(200, 'OK', []);
       $stream->write('Hello');
@@ -85,6 +85,21 @@ class TestOutputTest extends TestCase {
   #[@test]
   public function buffered_stream_via_constructor() {
     $fixture= TestOutput::buffered();
+    with ($fixture->stream(), function($stream) {
+      $stream->begin(200, 'OK', []);
+      $stream->write('Hello');
+      $stream->write('Test');
+    });
+    $this->assertEquals(
+      "HTTP/1.1 200 OK\r\nContent-Length: 9\r\n\r\nHelloTest",
+      $fixture->bytes()
+    );
+  }
+
+  /** @deprecated */
+  #[@test]
+  public function buffered_stream_with_using() {
+    $fixture= (new TestOutput())->using(Buffered::class);
     with ($fixture->stream(), function($stream) {
       $stream->begin(200, 'OK', []);
       $stream->write('Hello');


### PR DESCRIPTION
This pull request makes writing test code easier:

### Before

```php
use web\io\{TestOutput, Buffered};

$out= (new TestOutput())->using(Buffered::class);
```

### After

```php
use web\io\TestOutput

$out= TestOutput::buffered();
```

...or alternatively:

```php
use web\io\{TestOutput, Buffered};

$out= new TestOutput(Buffered::class);
```

**⚠️ The `using()` method is deprecated and will be removed in the next major release (2.0).**