### PR TITLE
Load stacktrace from cause of Error exception

### DIFF
--- a/src/main/php/xp/web/WebRunner.class.php
+++ b/src/main/php/xp/web/WebRunner.class.php
@@ -37,6 +37,7 @@ class WebRunner {
     } else {
       $loader= ClassLoader::getDefault();
       $message= Status::message($error->status());
+      $cause= $error->getCause();
 
       $response->answer($error->status(), $message);
       foreach (['web/error-'.$env->profile().'.html', 'web/error.html'] as $variant) {
@@ -46,7 +47,9 @@ class WebRunner {
           $error->status(),
           htmlspecialchars($message),
           htmlspecialchars($error->getMessage()),
-          htmlspecialchars($error->toString())
+          htmlspecialchars($cause
+            ? $cause->toString()
+            : $error->toString())
         ));
         break;
       }

--- a/src/main/php/xp/web/srv/HttpProtocol.class.php
+++ b/src/main/php/xp/web/srv/HttpProtocol.class.php
@@ -44,6 +44,7 @@ class HttpProtocol implements ServerProtocol {
     } else {
       $loader= ClassLoader::getDefault();
       $message= Status::message($error->status());
+      $cause= $error->getCause();
 
       $response->answer($error->status(), $message);
       foreach (['web/error-'.$this->application->environment()->profile().'.html', 'web/error.html'] as $variant) {
@@ -53,7 +54,9 @@ class HttpProtocol implements ServerProtocol {
           $error->status(),
           htmlspecialchars($message),
           htmlspecialchars($error->getMessage()),
-          htmlspecialchars($error->toString())
+          htmlspecialchars($cause
+            ? $cause->toString()
+            : $error->toString())
         ));
         break;
       }

--- a/src/test/php/web/unittest/HttpProtocolTest.class.php
+++ b/src/test/php/web/unittest/HttpProtocolTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace web\unittest;
 
 use io\streams\Streams;
+use lang\XPException;
 use unittest\TestCase;
 use web\Application;
 use web\Environment;
@@ -162,4 +163,16 @@ class HttpProtocolTest extends TestCase {
       $c->out
     );
   }
+
+  #[@test]
+  public function error_handling_stacktrace_from_cause() {
+    $p= new HttpProtocol($this->application(function($req, $res) {
+      throw new XPException('test');
+    }), $this->log);
+
+    $c= new Channel(["GET / HTTP/1.1\r\n\r\n"]);
+    $p->handleData($c);
+    $this->assertFalse(strpos(implode('', $c->out), 'Caused by Exception lang.XPException'));
+  }
+
 }


### PR DESCRIPTION
In https://github.com/xp-forge/frontend/pull/9 the stack trace is removed from the message of the error exception so this change is required to display it in dev environments.

This change is still compatible with old versions of xp-forge/frontend.