### PR TITLE
Also accept filter functions in constructor

### DIFF
--- a/src/main/php/web/Filters.class.php
+++ b/src/main/php/web/Filters.class.php
@@ -2,6 +2,13 @@
 
 use web\filters\Invocation;
 
+/**
+ * Filters acts as a handler and invokes all filters before passing control
+ * on to the given handler.
+ *
+ * @see   xp://web.Filter
+ * @test  xp://web.unittest.FiltersTest
+ */
 class Filters implements Handler {
   private $filters= [];
 

--- a/src/main/php/web/Filters.class.php
+++ b/src/main/php/web/Filters.class.php
@@ -3,18 +3,32 @@
 use web\filters\Invocation;
 
 class Filters implements Handler {
+  private $filters= [];
 
   /**
    * Creates a new instance
    *
-   * @param  web.Filter[] $filters
+   * @param  (web.Filter|function(web.Request, web.Response, web.filters.Invocation)[] $filters
    * @param  [:web.Routing]|web.Routing $routing
    */
   public function __construct($filters, $routing) {
-    $this->filters= $filters;
+    foreach ($filters as $filter) {
+      if ($filter instanceof Filter) {
+        $this->filters[]= $filter;
+      } else {
+        $this->filters[]= newinstance(Filter::class, [], ['filter' => $filter]);
+      }
+    }
     $this->routing= Routing::cast($routing);
   }
 
+  /**
+   * Filter request
+   *
+   * @param  web.Request $request
+   * @param  web.Response $response
+   * @param  var
+   */
   public function handle($request, $response) {
     return (new Invocation($this->routing, $this->filters))->proceed($request, $response);
   }

--- a/src/test/php/web/unittest/FiltersTest.class.php
+++ b/src/test/php/web/unittest/FiltersTest.class.php
@@ -1,0 +1,69 @@
+<?php namespace web\unittest;
+
+use unittest\TestCase;
+use web\Filter;
+use web\Filters;
+use web\Request;
+use web\Response;
+use web\io\TestInput;
+use web\io\TestOutput;
+
+class FiltersTest extends TestCase {
+
+  #[@test]
+  public function can_create() {
+    new Filters([], function($req, $res) { });
+  }
+
+  #[@test]
+  public function runs_handler() {
+    $req= new Request(new TestInput('GET', '/'));
+    $res= new Response(new TestOutput());
+
+    $invoked= [];
+    $fixture= new Filters([], function($req, $res) use(&$invoked) {
+      $invoked[]= $req->method().' '.$req->uri()->path();
+    });
+    $fixture->handle($req, $res);
+
+    $this->assertEquals(['GET /'], $invoked);
+  }
+
+  #[@test]
+  public function filter_instance() {
+    $req= new Request(new TestInput('GET', '/'));
+    $res= new Response(new TestOutput());
+
+    $invoked= [];
+    $filter= newinstance(Filter::class, [], [
+      'filter' => function($req, $res, $invocation) {
+        $req->rewrite($req->uri()->using()->path('/rewritten')->create());
+        return $invocation->proceed($req, $res);
+      }
+    ]);
+    $fixture= new Filters([$filter], function($req, $res) use(&$invoked) {
+      $invoked[]= $req->method().' '.$req->uri()->path();
+    });
+    $fixture->handle($req, $res);
+
+    $this->assertEquals(['GET /rewritten'], $invoked);
+  }
+
+  #[@test]
+  public function filter_function() {
+    $req= new Request(new TestInput('GET', '/'));
+    $res= new Response(new TestOutput());
+
+    $invoked= [];
+    $filter= function($req, $res, $invocation) {
+      $req->rewrite($req->uri()->using()->path('/rewritten')->create());
+      return $invocation->proceed($req, $res);
+    };
+    $fixture= new Filters([$filter], function($req, $res) use(&$invoked) {
+      $invoked[]= $req->method().' '.$req->uri()->path();
+    });
+    $fixture->handle($req, $res);
+
+    $this->assertEquals(['GET /rewritten'], $invoked);
+  }
+}


### PR DESCRIPTION
Following the *be liberal in what you accept* principle, the following is now also possible:

```php
$filter= function($request, $response, $invocation) {
  // TBI
};
$handler= function($request, $response) {
  // TBI
};

new Filters([$authenticate], $handler);
```

Previously, the arguments to *Filters*' constructor needed to be wrapped in *Filter* instance, while handlers need not.