### PR TITLE
Parse multipart payloads up until the first file

### DIFF
--- a/src/main/php/web/Multipart.class.php
+++ b/src/main/php/web/Multipart.class.php
@@ -12,34 +12,68 @@ use web\io\Part;
 class Multipart {
   const MIME = 'multipart/form-data';
 
-  private $request, $boundary;
+  private $parts, $params;
+  private $peeked= null;
 
   /**
    * Creates a new Multipart instance
    *
-   * @param  web.Request $request
-   * @param  web.Parameterized $type
+   * @param  iterable $parts
+   * @param  [:var] $params
    */
-  public function __construct($request, $type) {
-    $this->request= $request;
-    $this->boundary= $type->param('boundary');
+  public function __construct($parts, &$params) {
+    if ($parts instanceof \Iterator) {
+      $this->parts= $parts;
+    } else if ($parts instanceof \IteratorAggregate) {
+      $this->parts= $parts->getIterator();
+    } else {
+      $this->parts= new \ArrayIterator($parts);
+    }
+    $this->params= &$params;
   }
 
-  /** @return string */
-  public function boundary() { return $this->boundary; }
- 
+  /**
+   * Returns all parameters *before* files, parsing the request body until
+   * that position.
+   *
+   * @return web.io.Param[]
+   */
+  public function peek() {
+    if (null !== $this->peeked) return $this->peeked;
+
+    $this->peeked= [];
+    while ($this->parts->valid()) {
+      $part= $this->parts->current();
+      if (Part::PARAM !== $part->kind()) break;
+
+      parse_str($this->parts->key().'='.$part->value(), $params);
+      $this->params= array_merge_recursive($this->params, $params);
+      $this->parts->next();
+      $this->peeked[]= $part;
+    }
+    return $this->peeked;
+  }
+
   /**
    * Returns all parts - files and parameters.
    *
    * @return iterable
    */
   public function parts() {
-    foreach ($this->request->input()->parts($this->boundary) as $name => $part) {
+    if ($this->peeked) foreach ($this->peeked as $param) {
+      yield $param->name() => $param;
+    }
+    $this->peeked= [];
+
+    while ($this->parts->valid()) {
+      $name= $this->parts->key();
+      $part= $this->parts->current();
       if (Part::PARAM === $part->kind()) {
         parse_str($name.'='.$part->value(), $params);
-        $this->request->add($params);
+        $this->params= array_merge_recursive($this->params, $params);
       }
       yield $name => $part;
+      $this->parts->next();
     }
   }
 
@@ -49,14 +83,19 @@ class Multipart {
    * @return iterable
    */
   public function files() {
-    foreach ($this->request->input()->parts($this->boundary) as $name => $part) {
+    $this->peeked= [];
+
+    while ($this->parts->valid()) {
+      $name= $this->parts->key();
+      $part= $this->parts->current();
       $kind= $part->kind();
       if (Part::PARAM === $kind) {
         parse_str($name.'='.$part->value(), $params);
-        $this->request->add($params);
+        $this->params= array_merge_recursive($this->params, $params);
       } else if (Part::FILE === $kind) {
         yield $part->name() => $part;
       }
+      $this->parts->next();
     }
   }
 }

--- a/src/main/php/web/Multipart.class.php
+++ b/src/main/php/web/Multipart.class.php
@@ -46,8 +46,7 @@ class Multipart {
       $part= $this->parts->current();
       if (Part::PARAM !== $part->kind()) break;
 
-      parse_str($this->parts->key().'='.$part->value(), $params);
-      $this->params= array_merge_recursive($this->params, $params);
+      $this->params= $part->append($this->params);
       $this->parts->next();
       $this->peeked[]= $part;
     }
@@ -69,8 +68,7 @@ class Multipart {
       $name= $this->parts->key();
       $part= $this->parts->current();
       if (Part::PARAM === $part->kind()) {
-        parse_str($name.'='.$part->value(), $params);
-        $this->params= array_merge_recursive($this->params, $params);
+        $this->params= $part->append($this->params);
       }
       yield $name => $part;
       $this->parts->next();
@@ -90,8 +88,7 @@ class Multipart {
       $part= $this->parts->current();
       $kind= $part->kind();
       if (Part::PARAM === $kind) {
-        parse_str($name.'='.$part->value(), $params);
-        $this->params= array_merge_recursive($this->params, $params);
+        $this->params= $part->append($this->params);
       } else if (Part::FILE === $kind) {
         yield $part->name() => $part;
       }

--- a/src/main/php/web/Request.class.php
+++ b/src/main/php/web/Request.class.php
@@ -3,7 +3,7 @@
 use io\streams\{MemoryInputStream, Streams};
 use lang\Value;
 use util\{Objects, URI};
-use web\io\{Input, Part};
+use web\io\Input;
 
 class Request implements Value {
   private $stream= null;

--- a/src/main/php/web/Request.class.php
+++ b/src/main/php/web/Request.class.php
@@ -3,10 +3,11 @@
 use io\streams\{MemoryInputStream, Streams};
 use lang\Value;
 use util\{Objects, URI};
-use web\io\Input;
+use web\io\{Input, Part};
 
 class Request implements Value {
   private $stream= null;
+  private $multipart= null;
   private $lookup= [];
   private $headers= [];
   private $values= [];
@@ -116,9 +117,10 @@ class Request implements Value {
    * Parses payload into parameters and handles encoding (both cached)
    *
    * @see    http://www.w3.org/TR/html5/forms.html#application/x-www-form-urlencoded-encoding-algorithm
+   * @param  bool $peek Whether to peek multipart requests for parameters
    * @return void
    */
-  private function parse() {
+  private function parse($peek= true) {
     if (null !== $this->params) return;
 
     // Merge parameters from URL and urlencoded payload.
@@ -130,6 +132,12 @@ class Request implements Value {
       $query.= '&'.$data;
     }
     parse_str($query, $this->params);
+
+    // Read multipart bodies up until the first non-parameter part
+    if (Multipart::MIME === $type->value()) {
+      $this->multipart= new Multipart($this->input()->parts($type->param('boundary')), $this->params);
+      $peek && $this->multipart->peek();
+    }
 
     // Be liberal in what we accept and support "; charset=XXX" although the spec
     // states this media type does not have parameters! Then, handle the special
@@ -174,17 +182,6 @@ class Request implements Value {
         }
       }
     }
-  }
-
-  /**
-   * Adds parameters
-   *
-   * @param  [:var] $params
-   */
-  public function add($params) {
-    $this->parse();
-
-    $this->params= array_merge_recursive($this->params, $params);
   }
 
   /**
@@ -284,11 +281,8 @@ class Request implements Value {
    * @return ?web.io.Multipart
    */
   public function multipart() {
-    $type= Headers::parameterized()->parse($this->header('Content-Type'));
-    if (Multipart::MIME === $type->value()) {
-      return new Multipart($this, $type);
-    }
-    return null;
+    $this->parse(false);
+    return $this->multipart;
   }
 
   /**

--- a/src/main/php/web/io/Param.class.php
+++ b/src/main/php/web/io/Param.class.php
@@ -21,6 +21,17 @@ class Param extends Part {
     }
   }
 
+  /**
+   * Append this parameter to a given list of parameters and return the new list
+   *
+   * @param  [:var] $params
+   * @return [:var]
+   */
+  public function append($params) {
+    parse_str($this->name.'='.$this->value, $param);
+    return array_merge_recursive($params, $param);
+  }
+
   /** @return int */
   public function kind() { return Part::PARAM; }
 

--- a/src/main/php/xp/web/SAPI.class.php
+++ b/src/main/php/xp/web/SAPI.class.php
@@ -1,6 +1,6 @@
 <?php namespace xp\web;
 
-use web\io\{Buffered, Input, Output, ReadStream, ReadLength, WriteChunks, Incomplete};
+use web\io\{Buffered, Input, Output, Param, ReadStream, ReadLength, WriteChunks, Incomplete};
 
 /**
  * Wrapper for PHP's Server API ("SAPI").
@@ -79,7 +79,8 @@ class SAPI extends Output implements Input {
   public function incoming() { return $this->incoming; }
 
   /**
-   * Returns parts from a multipart/form-data request
+   * Returns parts from a multipart/form-data request. Includes all request parameters
+   * up-front as there is no way to know the order in which they were originally passed.
    *
    * @see    https://www.php.net/manual/en/reserved.variables.files.php
    * @see    https://www.php.net/manual/en/ini.core.php#ini.sect.file-uploads
@@ -87,6 +88,9 @@ class SAPI extends Output implements Input {
    * @return iterable
    */
   public function parts($boundary) {
+    foreach ($_REQUEST as $name => $value) {
+      yield $name => new Param($name, [urlencode($value)]);
+    }
     foreach ($_FILES as $name => $file) {
       if (is_array($file['error'])) {
         $name.= '[]';

--- a/src/test/php/web/unittest/MultipartRequestTest.class.php
+++ b/src/test/php/web/unittest/MultipartRequestTest.class.php
@@ -100,6 +100,19 @@ class MultipartRequestTest extends TestCase {
     $this->assertEquals(['tc' => 'Checked', 'submit' => 'Upload'], $params);
   }
 
+  #[@test]
+  public function only_parameters_before_files_accessible_before_handling_files() {
+    $req= new Request(new TestInput('POST', '/', self::$MULTIPART, $this->multipart([
+      $this->param('tc', 'Checked'),
+      $this->file('first.txt', 'First'),
+      $this->param('submit', 'Upload')
+    ])));
+
+    $this->assertEquals(['tc' => 'Checked'], $req->params(), 'Before iterating parts');
+    iterator_count($req->multipart()->parts());
+    $this->assertEquals(['tc' => 'Checked', 'submit' => 'Upload'], $req->params(), 'When complete');
+  }
+
   #[@test, @values([
   #  ['/', []],
   #  ['/?a=b', ['a' => 'b']],

--- a/src/test/php/web/unittest/server/SAPITest.class.php
+++ b/src/test/php/web/unittest/server/SAPITest.class.php
@@ -205,4 +205,13 @@ class SAPITest extends TestCase {
     $parts= $this->parts($this->incomplete('test.txt', UPLOAD_ERR_PARTIAL));
     Streams::readAll($parts['file']);
   }
+
+  #[@test]
+  public function parameters_yielded_by_parts() {
+    $_REQUEST= ['submit' => 'Test'];
+    $this->assertEquals(['submit' => 'web.io.Param', 'file' => 'xp.web.Upload'], array_map(
+      function($part) { return nameof($part); },
+      $this->parts($this->upload('test.txt', 'text/plain'))
+    ));
+  }
 }


### PR DESCRIPTION
This is done to make parameters passed along with multipart payloads accessible even before processing all uploaded files. The usecase is to pass a CSRF token as a hidden field, and have that validated before processing the files, something that e.g. xp-forge/frontend does automatically.

See also PR #65 and https://gist.github.com/thekid/3bb2b6cd099f58bce85fa8447103a833