### PR TITLE
Asynchronous file handling

### DIFF
--- a/src/main/php/web/handler/FilesFrom.class.php
+++ b/src/main/php/web/handler/FilesFrom.class.php
@@ -6,7 +6,8 @@ use web\Handler;
 use web\io\Ranges;
 
 class FilesFrom implements Handler {
-  const BOUNDARY = '594fa07300f865fe';
+  const BOUNDARY  = '594fa07300f865fe';
+  const CHUNKSIZE = 8192;
 
   private $path;
 
@@ -60,7 +61,7 @@ class FilesFrom implements Handler {
     $file->seek($range->start());
 
     $length= $range->length();
-    while ($length && $chunk= $file->read(min(8192, $length))) {
+    while ($length && $chunk= $file->read(min(self::CHUNKSIZE, $length))) {
       $output->write($chunk);
       $length-= strlen($chunk);
       yield;
@@ -105,7 +106,7 @@ class FilesFrom implements Handler {
       $file->open(File::READ);
       try {
         do {
-          $out->write($file->read());
+          $out->write($file->read(self::CHUNKSIZE));
           yield;
         } while (!$file->eof());
       } finally {

--- a/src/main/php/web/handler/FilesFrom.class.php
+++ b/src/main/php/web/handler/FilesFrom.class.php
@@ -102,11 +102,15 @@ class FilesFrom implements Handler {
       $response->header('Content-Type', $mimeType);
 
       $out= $response->stream($file->size());
-      $file->open(File::READ);
-      do {
-        $out->write($file->read());
-        yield;
-      } while (!$file->eof());
+      try {
+        $file->open(File::READ);
+        do {
+          $out->write($file->read());
+          yield;
+        } while (!$file->eof());
+      } finally {
+        $file->close();
+      }
       return;
     }
 


### PR DESCRIPTION
This pull request makes handling files, including ranges, interruptible as [described here](https://github.com/xp-forge/web/issues/70#issuecomment-809185160). This way, file downloads will not block the entire server.

Using this Download class:

```php
use web\Application;
use web\handler\FilesFrom;

class Download extends Application {

  public function routes() {
    return ['/' => new FilesFrom('.')];
  }
}
```

...and starting the server with `-m async`, we can see how two parallel downloads can run simultaneously:

![image](https://user-images.githubusercontent.com/696742/113182702-7e124700-9253-11eb-9734-ea923b05b0c6.png)
