### PR TITLE
Add new async method Response::transmit() replacing Response::transfer()

### DIFF
--- a/src/main/php/web/Response.class.php
+++ b/src/main/php/web/Response.class.php
@@ -2,7 +2,7 @@
 
 use io\Channel;
 use io\streams\InputStream;
-use lang\IllegalStateException;
+use lang\{IllegalStateException, IllegalArgumentException};
 use web\io\WriteChunks;
 
 /**

--- a/src/main/php/web/Response.class.php
+++ b/src/main/php/web/Response.class.php
@@ -170,6 +170,7 @@ class Response {
   /**
    * Transfers a stream
    *
+   * @deprecated Use `yield from $this->transmit(...)` instead!
    * @param  io.streams.InputStream $in
    * @param  string $mediaType
    * @param  int $size If omitted, uses chunked transfer encoding
@@ -189,10 +190,34 @@ class Response {
   }
 
   /**
+   * Transmits a stream
+   *
+   * @param  io.streams.InputStream $in
+   * @param  string $mediaType
+   * @param  int $size If omitted, uses chunked transfer encoding
+   * @return iterable
+   */
+  public function transmit($in, $mediaType= 'application/octet-stream', $size= null) {
+    $this->headers['Content-Type']= [$mediaType];
+
+    $out= $this->stream($size);
+    try {
+      while ($in->available()) {
+        $out->write($in->read());
+        yield;
+      }
+    } finally {
+      $out->close();
+      $in->close();
+    }
+  }
+
+  /**
    * Sends some content
    *
    * @param  string $content
    * @param  string $mediaType
+   * @return void
    */
   public function send($content, $mediaType= 'text/html') {
     $this->headers['Content-Type']= [$mediaType];

--- a/src/test/php/web/unittest/ResponseTest.class.php
+++ b/src/test/php/web/unittest/ResponseTest.class.php
@@ -204,6 +204,43 @@ class ResponseTest extends \unittest\TestCase {
   }
 
   #[Test]
+  public function transmit_stream_with_length() {
+    $res= new Response(new TestOutput());
+    foreach ($res->transmit(new MemoryInputStream('<h1>Test</h1>'), 'text/html', 13) as $_) { }
+
+    $this->assertResponse(
+      "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 13\r\n\r\n".
+      "<h1>Test</h1>",
+      $res
+    );
+  }
+
+  #[Test]
+  public function transmit_stream_chunked() {
+    $res= new Response(new TestOutput());
+    foreach ($res->transmit(new MemoryInputStream('<h1>Test</h1>'), 'text/html') as $_) { }
+
+    $this->assertResponse(
+      "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nTransfer-Encoding: chunked\r\n\r\n".
+      "d\r\n<h1>Test</h1>\r\n0\r\n\r\n",
+      $res
+    );
+  }
+
+  #[Test]
+  public function transmit_stream_buffered() {
+    $res= new Response((new TestOutput())->using(Buffered::class));
+    foreach ($res->transmit(new MemoryInputStream('<h1>Test</h1>'), 'text/html') as $_) { }
+
+    $this->assertResponse(
+      "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 13\r\n\r\n".
+      "<h1>Test</h1>",
+      $res
+    );
+  }
+
+
+  #[Test]
   public function cookies_and_headers_are_merged() {
     $res= new Response(new TestOutput());
     $res->header('Content-Type', 'text/html');

--- a/src/test/php/web/unittest/ResponseTest.class.php
+++ b/src/test/php/web/unittest/ResponseTest.class.php
@@ -2,7 +2,8 @@
 
 use io\Channel;
 use io\streams\MemoryInputStream;
-use unittest\{Test, Values, TestCase};
+use lang\IllegalArgumentException;
+use unittest\{Test, Expect, Values, TestCase};
 use util\URI;
 use web\io\{Buffered, TestOutput};
 use web\{Cookie, Response};
@@ -254,6 +255,12 @@ class ResponseTest extends TestCase {
       "<h1>Test</h1>",
       $res
     );
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function transmit_null() {
+    $res= new Response(new TestOutput());
+    foreach ($res->transmit(null) as $_) { }
   }
 
   #[Test]

--- a/src/test/php/web/unittest/ResponseTest.class.php
+++ b/src/test/php/web/unittest/ResponseTest.class.php
@@ -1,12 +1,13 @@
 <?php namespace web\unittest;
 
+use io\Channel;
 use io\streams\MemoryInputStream;
-use unittest\{Test, Values};
+use unittest\{Test, Values, TestCase};
 use util\URI;
 use web\io\{Buffered, TestOutput};
 use web\{Cookie, Response};
 
-class ResponseTest extends \unittest\TestCase {
+class ResponseTest extends TestCase {
 
   /**
    * Assertion helper
@@ -239,6 +240,21 @@ class ResponseTest extends \unittest\TestCase {
     );
   }
 
+  #[Test]
+  public function transmit_channel() {
+    $res= new Response(new TestOutput());
+    $channel= new class() implements Channel {
+      public function in() { return new MemoryInputStream('<h1>Test</h1>'); }
+      public function out() { /* Not implemented */ }
+    };
+    foreach ($res->transmit($channel, 'text/html', 13) as $_) { }
+
+    $this->assertResponse(
+      "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 13\r\n\r\n".
+      "<h1>Test</h1>",
+      $res
+    );
+  }
 
   #[Test]
   public function cookies_and_headers_are_merged() {


### PR DESCRIPTION
The `transfer()` method will be deprecated (and then removed at a later point!). Existing code will continue to work, but should be rewritten as follows:

```diff
-$response->transfer($file->in(), MimeUtil::getByFileName($file->filename), $file->size());
+yield from $response->transmit($file->in(), MimeUtil::getByFileName($file->filename), $file->size());
```