### PR TITLE
Add new FilesFrom::with($headers) to add custom headers

### DIFF
--- a/src/main/php/web/handler/FilesFrom.class.php
+++ b/src/main/php/web/handler/FilesFrom.class.php
@@ -20,7 +20,7 @@ class FilesFrom implements Handler {
   /**
    * Adds headers, either from an array or a function.
    *
-   * @param  [:string]|function(io.File): iterable $headers
+   * @param  [:string]|function(util.URI, io.File, string): iterable $headers
    * @return self
    */
   public function with($headers) {
@@ -105,15 +105,15 @@ class FilesFrom implements Handler {
       }
     }
 
+    $mimeType= MimeType::getByFileName($file->filename);
     $response->header('Accept-Ranges', 'bytes');
     $response->header('Last-Modified', gmdate('D, d M Y H:i:s T', $lastModified));
     $response->header('X-Content-Type-Options', 'nosniff');
-    $headers= is_callable($this->headers) ? ($this->headers)($target) : $this->headers;
+    $headers= is_callable($this->headers) ? ($this->headers)($request->uri(), $target, $mimeType) : $this->headers;
     foreach ($headers as $name => $value) {
       $response->header($name, $value);
     }
 
-    $mimeType= MimeType::getByFileName($file->filename);
     if (null === ($ranges= Ranges::in($request->header('Range'), $file->size()))) {
       $response->answer(200, 'OK');
       $response->header('Content-Type', $mimeType);

--- a/src/main/php/web/handler/FilesFrom.class.php
+++ b/src/main/php/web/handler/FilesFrom.class.php
@@ -18,9 +18,9 @@ class FilesFrom implements Handler {
   }
 
   /**
-   * Adds headers
+   * Adds headers, either from an array or a function.
    *
-   * @param  [:string] $headers
+   * @param  [:string]|function(io.File): iterable $headers
    * @return self
    */
   public function with($headers) {
@@ -108,7 +108,8 @@ class FilesFrom implements Handler {
     $response->header('Accept-Ranges', 'bytes');
     $response->header('Last-Modified', gmdate('D, d M Y H:i:s T', $lastModified));
     $response->header('X-Content-Type-Options', 'nosniff');
-    foreach ($this->headers as $name => $value) {
+    $headers= $this->headers instanceof \Closure ? ($this->headers)($target) : $this->headers;
+    foreach ($headers as $name => $value) {
       $response->header($name, $value);
     }
 

--- a/src/main/php/web/handler/FilesFrom.class.php
+++ b/src/main/php/web/handler/FilesFrom.class.php
@@ -85,12 +85,12 @@ class FilesFrom implements Handler {
    *
    * @param   web.Request $request
    * @param   web.Response $response
-   * @param   io.File|io.Path|string $target
+   * @param   ?io.File|io.Path|string $target
+   * @param   ?string $mimeType
    * @return  void
    */
-  public function serve($request, $response, $target) {
-    $file= $target instanceof File ? $target : new File($target);
-    if (!$file->exists()) {
+  public function serve($request, $response, $target, $mimeType= null) {
+    if (null === $target || ($file= $target instanceof File ? $target : new File($target)) && !$file->exists()) {
       $response->answer(404, 'Not Found');
       $response->send('The file \''.$request->uri()->path().'\' was not found', 'text/plain');
       return;
@@ -105,7 +105,7 @@ class FilesFrom implements Handler {
       }
     }
 
-    $mimeType= MimeType::getByFileName($file->filename);
+    $mimeType ?? $mimeType= MimeType::getByFileName($file->filename);
     $response->header('Accept-Ranges', 'bytes');
     $response->header('Last-Modified', gmdate('D, d M Y H:i:s T', $lastModified));
     $response->header('X-Content-Type-Options', 'nosniff');

--- a/src/main/php/web/handler/FilesFrom.class.php
+++ b/src/main/php/web/handler/FilesFrom.class.php
@@ -17,6 +17,9 @@ class FilesFrom implements Handler {
     $this->path= $path instanceof Path ? $path : new Path($path);
   }
 
+  /** @return io.Path */
+  public function path() { return $this->path; }
+
   /**
    * Adds headers to successful responses, either from an array or a function.
    *

--- a/src/main/php/web/handler/FilesFrom.class.php
+++ b/src/main/php/web/handler/FilesFrom.class.php
@@ -108,7 +108,7 @@ class FilesFrom implements Handler {
     $response->header('Accept-Ranges', 'bytes');
     $response->header('Last-Modified', gmdate('D, d M Y H:i:s T', $lastModified));
     $response->header('X-Content-Type-Options', 'nosniff');
-    $headers= $this->headers instanceof \Closure ? ($this->headers)($target) : $this->headers;
+    $headers= is_callable($this->headers) ? ($this->headers)($target) : $this->headers;
     foreach ($headers as $name => $value) {
       $response->header($name, $value);
     }

--- a/src/main/php/web/handler/FilesFrom.class.php
+++ b/src/main/php/web/handler/FilesFrom.class.php
@@ -10,10 +10,22 @@ class FilesFrom implements Handler {
   const CHUNKSIZE = 8192;
 
   private $path;
+  private $headers= [];
 
   /** @param io.Path|io.Folder|string $path */
   public function __construct($path) {
     $this->path= $path instanceof Path ? $path : new Path($path);
+  }
+
+  /**
+   * Adds headers
+   *
+   * @param  [:string] $headers
+   * @return self
+   */
+  public function with($headers) {
+    $this->headers= $headers;
+    return $this;
   }
 
   /**
@@ -96,6 +108,9 @@ class FilesFrom implements Handler {
     $response->header('Accept-Ranges', 'bytes');
     $response->header('Last-Modified', gmdate('D, d M Y H:i:s T', $lastModified));
     $response->header('X-Content-Type-Options', 'nosniff');
+    foreach ($this->headers as $name => $value) {
+      $response->header($name, $value);
+    }
 
     $mimeType= MimeType::getByFileName($file->filename);
     if (null === ($ranges= Ranges::in($request->header('Range'), $file->size()))) {

--- a/src/main/php/web/handler/FilesFrom.class.php
+++ b/src/main/php/web/handler/FilesFrom.class.php
@@ -18,7 +18,7 @@ class FilesFrom implements Handler {
   }
 
   /**
-   * Adds headers, either from an array or a function.
+   * Adds headers to successful responses, either from an array or a function.
    *
    * @param  [:string]|function(util.URI, io.File, string): iterable $headers
    * @return self

--- a/src/test/php/web/unittest/handler/FilesFromTest.class.php
+++ b/src/test/php/web/unittest/handler/FilesFromTest.class.php
@@ -120,6 +120,27 @@ class FilesFromTest extends TestCase {
   }
 
   #[Test]
+  public function existing_file_with_headers_function() {
+    $files= (new FilesFrom($this->pathWith(['test.html' => 'Test'])))->with(function($file) {
+      if (strstr($file->filename, '.html')) {
+        yield 'Cache-Control' => 'no-cache';
+      }
+    });
+    $this->assertResponse(
+      "HTTP/1.1 200 OK\r\n".
+      "Accept-Ranges: bytes\r\n".
+      "Last-Modified: <Date>\r\n".
+      "X-Content-Type-Options: nosniff\r\n".
+      "Cache-Control: no-cache\r\n".
+      "Content-Type: text/html\r\n".
+      "Content-Length: 4\r\n".
+      "\r\n".
+      "Test",
+      $this->handle($files, new Request(new TestInput('GET', '/test.html')))
+    );
+  }
+
+  #[Test]
   public function existing_file_unmodified_since() {
     $files= new FilesFrom($this->pathWith(['test.html' => 'Test']));
     $this->assertResponse(

--- a/src/test/php/web/unittest/handler/FilesFromTest.class.php
+++ b/src/test/php/web/unittest/handler/FilesFromTest.class.php
@@ -121,7 +121,7 @@ class FilesFromTest extends TestCase {
 
   #[Test]
   public function existing_file_with_headers_function() {
-    $files= (new FilesFrom($this->pathWith(['test.html' => 'Test'])))->with(function($file) {
+    $files= (new FilesFrom($this->pathWith(['test.html' => 'Test'])))->with(function($uri, $file, $mime) {
       if (strstr($file->filename, '.html')) {
         yield 'Cache-Control' => 'no-cache';
       }

--- a/src/test/php/web/unittest/handler/FilesFromTest.class.php
+++ b/src/test/php/web/unittest/handler/FilesFromTest.class.php
@@ -2,12 +2,12 @@
 
 use io\{File, FileUtil, Folder, Path};
 use lang\Environment;
-use unittest\{Test, Values};
+use unittest\{Test, TestCase, Values};
 use web\handler\FilesFrom;
 use web\io\{TestInput, TestOutput};
 use web\{Request, Response};
 
-class FilesFromTest extends \unittest\TestCase {
+class FilesFromTest extends TestCase {
   private $cleanup= [];
 
   /**
@@ -94,6 +94,23 @@ class FilesFromTest extends \unittest\TestCase {
       "Accept-Ranges: bytes\r\n".
       "Last-Modified: <Date>\r\n".
       "X-Content-Type-Options: nosniff\r\n".
+      "Content-Type: text/html\r\n".
+      "Content-Length: 4\r\n".
+      "\r\n".
+      "Test",
+      $this->handle($files, new Request(new TestInput('GET', '/test.html')))
+    );
+  }
+
+  #[Test]
+  public function existing_file_with_headers() {
+    $files= (new FilesFrom($this->pathWith(['test.html' => 'Test'])))->with(['Cache-Control' => 'no-cache']);
+    $this->assertResponse(
+      "HTTP/1.1 200 OK\r\n".
+      "Accept-Ranges: bytes\r\n".
+      "Last-Modified: <Date>\r\n".
+      "X-Content-Type-Options: nosniff\r\n".
+      "Cache-Control: no-cache\r\n".
       "Content-Type: text/html\r\n".
       "Content-Length: 4\r\n".
       "\r\n".

--- a/src/test/php/web/unittest/handler/FilesFromTest.class.php
+++ b/src/test/php/web/unittest/handler/FilesFromTest.class.php
@@ -106,6 +106,11 @@ class FilesFromTest extends TestCase {
     new FilesFrom(new Path('.'));
   }
 
+  #[Test, Values(eval: '[["."], [new Path(".")]]')]
+  public function path($arg) {
+    $this->assertEquals(new Path('.'), (new FilesFrom($arg))->path());
+  }
+
   #[Test]
   public function existing_file() {
     $files= new FilesFrom($this->pathWith(['test.html' => 'Test']));


### PR DESCRIPTION
Example:

```php
// Always use no-cache
$files= (new FilesFrom($path))->with(['Cache-Control' => 'no-cache']);

// Add checksum, see https://tools.ietf.org/html/rfc1864
$files= (new FilesFrom($path))->with(function($uri, $file, $mime) {
  yield 'Content-MD5' => md5_file($file->getURI());
});

// Decide caching strategy based on mime type
$files= (new FilesFrom($path))->with(function($uri, $file, $mime) {
  if ('text/html' === $mime) {
    yield 'Cache-Control' => 'no-cache';
  }
});
```

See also #71. Works similar to `setHeaders()` in [Express' serve-static](https://expressjs.com/en/resources/middleware/serve-static.html) 