### PR TITLE
Add Headers::date(int|util.Date) to return dates in GMT according to HTTP spec

### DIFF
--- a/src/main/php/web/Cookie.class.php
+++ b/src/main/php/web/Cookie.class.php
@@ -152,7 +152,7 @@ class Cookie implements Value {
   public function header() {
     return (
       $this->name.'='.$this->value.
-      (null === $this->expires ? '' : '; Expires='.gmdate('D, d M Y H:i:s \G\M\T', $this->expires)).
+      (null === $this->expires ? '' : '; Expires='.Headers::date($this->expires)).
       (null === $this->maxAge ? '' : '; Max-Age='.$this->maxAge).
       (null === $this->path ? '' : '; Path='.$this->path).
       (null === $this->domain ? '' : '; Domain='.$this->domain).

--- a/src/main/php/web/Headers.class.php
+++ b/src/main/php/web/Headers.class.php
@@ -18,8 +18,8 @@ abstract class Headers {
    * @param  ?int|util.Date $arg
    * @return string
    */
-  public static function date($arg) {
-    return gmdate('D, d M Y H:i:s T', $arg instanceof Date ? $arg->getTime() : $arg);
+  public static function date($arg= null) {
+    return gmdate('D, d M Y H:i:s \G\M\T', $arg instanceof Date ? $arg->getTime() : $arg);
   }
 
   /**

--- a/src/main/php/web/Headers.class.php
+++ b/src/main/php/web/Headers.class.php
@@ -1,6 +1,7 @@
 <?php namespace web;
 
 use lang\FormatException;
+use util\Date;
 
 /**
  * Parses headers
@@ -10,6 +11,16 @@ use lang\FormatException;
  * @test  xp://web.unittest.HeadersTest
  */
 abstract class Headers {
+
+  /**
+   * Formats a date for use in headers
+   *
+   * @param  ?int|util.Date $arg
+   * @return string
+   */
+  public static function date($arg) {
+    return gmdate('D, d M Y H:i:s T', $arg instanceof Date ? $arg->getTime() : $arg);
+  }
 
   /**
    * Parses a given input string and returns the parsed values

--- a/src/main/php/web/handler/FilesFrom.class.php
+++ b/src/main/php/web/handler/FilesFrom.class.php
@@ -2,8 +2,8 @@
 
 use io\{File, Path};
 use util\MimeType;
-use web\Handler;
 use web\io\Ranges;
+use web\{Handler, Headers};
 
 class FilesFrom implements Handler {
   const BOUNDARY  = '594fa07300f865fe';
@@ -110,7 +110,7 @@ class FilesFrom implements Handler {
 
     $mimeType ?? $mimeType= MimeType::getByFileName($file->filename);
     $response->header('Accept-Ranges', 'bytes');
-    $response->header('Last-Modified', gmdate('D, d M Y H:i:s T', $lastModified));
+    $response->header('Last-Modified', Headers::date($lastModified));
     $response->header('X-Content-Type-Options', 'nosniff');
     $headers= is_callable($this->headers) ? ($this->headers)($request->uri(), $target, $mimeType) : $this->headers;
     foreach ($headers as $name => $value) {

--- a/src/main/php/xp/web/WebRunner.class.php
+++ b/src/main/php/xp/web/WebRunner.class.php
@@ -1,7 +1,7 @@
 <?php namespace xp\web;
 
 use lang\ClassLoader;
-use web\{Environment, Error, InternalServerError, Request, Response, Status};
+use web\{Environment, Error, InternalServerError, Request, Response, Headers, Status};
 
 /**
  * Entry point for web-main.php
@@ -63,8 +63,7 @@ class WebRunner {
     $sapi= new SAPI();
     $request= new Request($sapi);
     $response= new Response($sapi);
-    $response->header('Date', gmdate('D, d M Y H:i:s T'));
-    $response->header('Host', $request->header('Host'));
+    $response->header('Date', Headers::date());
 
     try {
       $application= (new Source(getenv('WEB_SOURCE'), $env))->application();

--- a/src/main/php/xp/web/srv/HttpProtocol.class.php
+++ b/src/main/php/xp/web/srv/HttpProtocol.class.php
@@ -2,7 +2,7 @@
 
 use lang\{ClassLoader, Throwable};
 use peer\server\ServerProtocol;
-use web\{Error, InternalServerError, Request, Response, Status};
+use web\{Error, InternalServerError, Request, Response, Headers, Status};
 
 /**
  * HTTP protocol implementation
@@ -96,7 +96,7 @@ class HttpProtocol implements ServerProtocol {
       gc_enable();
       $request= new Request($input);
       $response= new Response(new Output($socket, $version));
-      $response->header('Date', gmdate('D, d M Y H:i:s T'));
+      $response->header('Date', Headers::date());
       $response->header('Server', 'XP');
 
       // HTTP/1.1 defaults to keeping connection alive, HTTP/1.0 defaults to closing

--- a/src/test/php/web/unittest/CookieTest.class.php
+++ b/src/test/php/web/unittest/CookieTest.class.php
@@ -3,7 +3,7 @@
 use lang\IllegalArgumentException;
 use unittest\{Expect, Test, TestCase, Values};
 use util\{Date, TimeSpan};
-use web\Cookie;
+use web\{Cookie, Headers};
 
 class CookieTest extends TestCase {
 
@@ -115,7 +115,7 @@ class CookieTest extends TestCase {
   #[Test]
   public function use_null_to_remove() {
     $this->assertEquals(
-      'name=; Expires='.gmdate('D, d M Y H:i:s \G\M\T', time() - 86400 * 365).'; Max-Age=0; SameSite=Lax; HttpOnly',
+      'name=; Expires='.Headers::date(time() - 86400 * 365).'; Max-Age=0; SameSite=Lax; HttpOnly',
       (new Cookie('name', null))->header()
     );
   }

--- a/src/test/php/web/unittest/HeadersTest.class.php
+++ b/src/test/php/web/unittest/HeadersTest.class.php
@@ -2,9 +2,21 @@
 
 use lang\FormatException;
 use unittest\{Expect, Test, TestCase, Values};
+use util\Date;
 use web\{Headers, Parameterized};
 
 class HeadersTest extends TestCase {
+  const TIMESTAMP = 1621063890;
+
+  #[Test]
+  public function date_of_int() {
+    $this->assertEquals('Sat, 15 May 2021 07:31:30 GMT', Headers::date(self::TIMESTAMP));
+  }
+
+  #[Test]
+  public function date_of_date_instance() {
+    $this->assertEquals('Sat, 15 May 2021 07:31:30 GMT', Headers::date(new Date(self::TIMESTAMP)));
+  }
 
   #[Test, Values(['text/plain;charset=utf-8', 'text/plain; charset=utf-8', 'text/plain; charset="utf-8"'])]
   public function content_type($header) {

--- a/src/test/php/web/unittest/handler/FilesFromTest.class.php
+++ b/src/test/php/web/unittest/handler/FilesFromTest.class.php
@@ -5,7 +5,7 @@ use lang\Environment;
 use unittest\{Test, TestCase, Values};
 use web\handler\FilesFrom;
 use web\io\{TestInput, TestOutput};
-use web\{Request, Response};
+use web\{Request, Response, Headers};
 
 class FilesFromTest extends TestCase {
   private $cleanup= [];
@@ -172,7 +172,7 @@ class FilesFromTest extends TestCase {
       "HTTP/1.1 304 Not Modified\r\n".
       "\r\n",
       $this->handle($files, new Request(new TestInput('GET', '/test.html', [
-        'If-Modified-Since' => gmdate('D, d M Y H:i:s T', time() + 1)
+        'If-Modified-Since' => Headers::date(time() + 1)
       ])))
     );
   }


### PR DESCRIPTION
Example:

```php
// Previously, we would have to know how to format the date
$req->header('Last-Modified', gmdate('D, d M Y H:i:s \G\M\T', $modified));

// Now, we can use the utility method, and have handling for util.Date instances included!
$req->header('Last-Modified', Headers::date($modified));
```

