### PR TITLE
Fixed usage of "&" chars in multipart params

### DIFF
--- a/src/main/php/web/io/Param.class.php
+++ b/src/main/php/web/io/Param.class.php
@@ -28,7 +28,7 @@ class Param extends Part {
    * @return [:var]
    */
   public function append($params) {
-    parse_str($this->name.'='.$this->value, $param);
+    parse_str($this->name.'='.urlencode($this->value), $param);
     return array_merge_recursive($params, $param);
   }
 

--- a/src/test/php/web/unittest/MultipartRequestTest.class.php
+++ b/src/test/php/web/unittest/MultipartRequestTest.class.php
@@ -182,4 +182,15 @@ class MultipartRequestTest extends TestCase {
     }
     $this->assertEquals(['test.txt' => $length], $files);
   }
+
+  #[Test]
+  public function and_char_not_supported_regression() {
+    $req= new Request(new TestInput('POST', '/', self::$MULTIPART, $this->multipart([
+      $this->param('test', 'illegal&char')
+    ])));
+
+    iterator_count($req->multipart()->parts());
+    $this->assertEquals(['test' => 'illegal&char'], $req->params());
+  }
+
 }


### PR DESCRIPTION
Parameters sent as multipart request cannot contain the "&" char in their value.