### PR TITLE
Fixed param value is urlencoded when doing multipart requests vie SAPI

### DIFF
--- a/src/main/php/xp/web/SAPI.class.php
+++ b/src/main/php/xp/web/SAPI.class.php
@@ -89,7 +89,7 @@ class SAPI extends Output implements Input {
    */
   public function parts($boundary) {
     foreach ($_REQUEST as $name => $value) {
-      yield $name => new Param($name, [urlencode($value)]);
+      yield $name => new Param($name, [$value]);
     }
     foreach ($_FILES as $name => $file) {
       if (is_array($file['error'])) {

--- a/src/test/php/web/unittest/server/SAPITest.class.php
+++ b/src/test/php/web/unittest/server/SAPITest.class.php
@@ -214,4 +214,12 @@ class SAPITest extends TestCase {
       $this->parts($this->upload('test.txt', 'text/plain'))
     ));
   }
+
+  #[Test]
+  public function parameter_unnecessary_urlencode_regression() {
+    $_REQUEST= ['varname' => 'the value'];
+    $fixture= new SAPI();
+    $parts = iterator_to_array($fixture->parts(''));
+    $this->assertNotEquals('the+value', $parts['varname']->value());
+  }
 }


### PR DESCRIPTION
When multipart requests are used, all parameter values wil be urlencoded but never decoded.
I think, with the change from the pull request https://github.com/xp-forge/web/pull/80 the urlencode in SAPI::parts is unnecessary.