### PR TITLE
Default server profile to "prod"

### DIFF
--- a/src/main/php/xp/web/Runner.class.php
+++ b/src/main/php/xp/web/Runner.class.php
@@ -46,7 +46,7 @@ class Runner {
     $webroot= new Path(getcwd());
     $docroot= new Path($webroot, 'static');
     $address= 'localhost:8080';
-    $profile= getenv('SERVER_PROFILE') ?: 'dev';
+    $profile= getenv('SERVER_PROFILE');
     $server= Servers::$ASYNC;
     $arguments= [];
     $config= [];
@@ -80,7 +80,7 @@ class Runner {
 
       $server->newInstance($address, $arguments)->serve(
         $source,
-        $profile,
+        $profile ?: (Servers::$DEVELOP === $server ? 'dev' : 'prod'),
         $webroot,
         $webroot->resolve($docroot),
         $config,

--- a/src/main/php/xp/web/srv/Develop.class.php
+++ b/src/main/php/xp/web/srv/Develop.class.php
@@ -55,7 +55,7 @@ class Develop extends Server {
     putenv('WEB_LOG='.$logging);
 
     Console::writeLine("\e[33m@", nameof($this), "(HTTP @ `php ", implode(' ', $arguments), "`)\e[0m");
-    Console::writeLine("\e[1mServing ", $source, $config, "\e[0m > ", Logging::of($logging)->target());
+    Console::writeLine("\e[1mServing {$profile}:", $source, $config, "\e[0m > ", Logging::of($logging)->target());
     Console::writeLine("\e[36m", str_repeat('═', 72), "\e[0m");
     Console::writeLine();
 

--- a/src/main/php/xp/web/srv/Standalone.class.php
+++ b/src/main/php/xp/web/srv/Standalone.class.php
@@ -63,7 +63,7 @@ class Standalone extends Server {
     $this->impl->init();
 
     Console::writeLine("\e[33m@", nameof($this), '(HTTP @ ', $socket->toString(), ")\e[0m");
-    Console::writeLine("\e[1mServing ", $application, $config, "\e[0m > ", $environment->logging()->target());
+    Console::writeLine("\e[1mServing {$profile}:", $application, $config, "\e[0m > ", $environment->logging()->target());
     Console::writeLine("\e[36m", str_repeat('═', 72), "\e[0m");
 
     Console::writeLinef(


### PR DESCRIPTION
This way, stack traces are no longer displayed by default. Server mode is set to "dev" if not explicitely defined when using the development webserver via `-m develop`