### PR TITLE
Add optional parameter $append to cookie()

### DIFF
--- a/src/main/php/web/Response.class.php
+++ b/src/main/php/web/Response.class.php
@@ -38,11 +38,16 @@ class Response {
   /**
    * Sets a cookie
    *
-   * @param  web.Response $cookie
+   * @param  web.Cookie $cookie
+   * @param  bool $append Append header if already existant
    * @return void
    */
-  public function cookie(Cookie $cookie) {
-    $this->cookies[]= $cookie;
+  public function cookie(Cookie $cookie, $append= false) {
+    if ($append) {
+      $this->cookies[]= $cookie;
+    } else {
+      $this->cookies[$cookie->name()]= $cookie;
+    }
   }
 
   /**
@@ -81,7 +86,7 @@ class Response {
   public function flushed() { return $this->flushed; }
 
   /** @return web.Cookie[] */
-  public function cookies() { return $this->cookies; }
+  public function cookies() { return array_values($this->cookies); }
 
   /** @return [:string|string[]] */
   public function headers() {

--- a/src/test/php/web/unittest/ResponseTest.class.php
+++ b/src/test/php/web/unittest/ResponseTest.class.php
@@ -115,6 +115,22 @@ class ResponseTest extends TestCase {
   }
 
   #[Test]
+  public function overwrite_cookie() {
+    $res= new Response(new TestOutput());
+    $res->cookie(new Cookie('theme', 'light'));
+    $res->cookie(new Cookie('theme', 'dark'));
+    $this->assertEquals(['dark'], array_map(function($c) { return $c->value(); }, $res->cookies()));
+  }
+
+  #[Test]
+  public function append_cookie() {
+    $res= new Response(new TestOutput());
+    $res->cookie(new Cookie('theme', 'light'));
+    $res->cookie(new Cookie('theme', 'dark'), true);
+    $this->assertEquals(['light', 'dark'], array_map(function($c) { return $c->value(); }, $res->cookies()));
+  }
+
+  #[Test]
   public function cookies() {
     $cookies= [new Cookie('theme', 'Test'), (new Cookie('sessionToken', 'abc123'))->expires('Wed, 09 Jun 2021 10:18:14 GMT')];
 


### PR DESCRIPTION
This parameter controls whether cookies are overwritten (the default behavior, calling cookie() twice with a cookie of the same name will yield only one `Set-Cookie: name=value` header) or appended (creating multiple cookies with the same name, which may desirable if they vary in path / domain).

## Warning: BC break in rare cases

The following code will behave differently when this PR is merged:

```php
$res->cookie(new Cookie('theme', 'light'));
$res->cookie(new Cookie('theme', 'dark'));
```

Before, it would yield two headers:

```
Set-Cookie: theme=light
Set-Cookie: theme=dark
```

**After this change, only one the header with the cookie value *dark* would be sent!**

👉I decided to go this way to make the *cookie()* method consistent with *header()*, which also by defaults to overwriting headers; instead of going the other (BC-break free) way around.

## Updating code

If you need multiple Set-Cookie headers for a cookie with the *same* name, you would have to rewrite the above code as follows:

```php
$res->cookie(new Cookie('theme', 'light'));
$res->cookie(new Cookie('theme', 'dark'), append: true);
```

See https://stackoverflow.com/questions/4056306/how-to-handle-multiple-cookies-with-the-same-name