### PR TITLE
URL-encode cookie values

### DIFF
--- a/src/main/php/web/Cookie.class.php
+++ b/src/main/php/web/Cookie.class.php
@@ -151,7 +151,7 @@ class Cookie implements Value {
   /** @return string */
   public function header() {
     return (
-      $this->name.'='.$this->value.
+      $this->name.'='.rawurlencode($this->value).
       (null === $this->expires ? '' : '; Expires='.Headers::date($this->expires)).
       (null === $this->maxAge ? '' : '; Max-Age='.$this->maxAge).
       (null === $this->path ? '' : '; Path='.$this->path).

--- a/src/main/php/web/Cookie.class.php
+++ b/src/main/php/web/Cookie.class.php
@@ -42,7 +42,7 @@ class Cookie implements Value {
   /** @return string */
   public function name() { return $this->name; }
 
-  /** @return string */
+  /** @return ?string */
   public function value() { return $this->value; }
 
   /** @return [:var] */
@@ -61,7 +61,7 @@ class Cookie implements Value {
   /**
    * Set expiration date
    *
-   * @param  int|string|util.Date $expires
+   * @param  ?int|string|util.Date $expires
    * @return self
    */
   public function expires($expires) {
@@ -78,7 +78,7 @@ class Cookie implements Value {
   /**
    * Set maximum age in seconds.
    *
-   * @param  int|util.TimeSpan $maxAge
+   * @param  ?int|util.TimeSpan $maxAge
    * @return self
    */
   public function maxAge($maxAge) {
@@ -93,7 +93,7 @@ class Cookie implements Value {
   /**
    * Restricts to a given path. Use `/` for all paths on a given domain
    *
-   * @param  string $path
+   * @param  ?string $path
    * @return self
    */
   public function path($path) {
@@ -104,7 +104,7 @@ class Cookie implements Value {
   /**
    * Restricts to a given domain. Prefix with `.` to make valid for all subdomains
    *
-   * @param  string $domain
+   * @param  ?string $domain
    * @return self
    */
   public function domain($domain) {
@@ -137,7 +137,7 @@ class Cookie implements Value {
   /**
    * Switch whether to only transmit only to same site; preventing CSRF
    *
-   * @param  string $sameSite one of "Strict", "Lax" or null (use the latter to remove)
+   * @param  ?string $sameSite one of "Strict", "Lax" or null (use the latter to remove)
    * @return self
    */
   public function sameSite($sameSite) {

--- a/src/main/php/web/Cookie.class.php
+++ b/src/main/php/web/Cookie.class.php
@@ -4,12 +4,13 @@ use lang\{IllegalArgumentException, Value};
 use util\{Date, TimeSpan};
 
 /**
- * A HTTP/1.1 Cookie
+ * A HTTP/1.1 Cookie. Values are encoded using URL encoding.
  *
  * @see   https://tools.ietf.org/html/rfc6265
  * @see   http://httpwg.org/http-extensions/draft-ietf-httpbis-cookie-same-site.html
  * @see   https://www.owasp.org/index.php/SameSite
- * @test  xp://web.unittest.CookieTest
+ * @see   https://developer.mozilla.org/en-US/docs/Web/API/document/cookie
+ * @test  web.unittest.CookieTest
  */
 class Cookie implements Value {
   private $name, $value;

--- a/src/main/php/web/Cookie.class.php
+++ b/src/main/php/web/Cookie.class.php
@@ -27,7 +27,6 @@ class Cookie implements Value {
    *
    * @param  string $name
    * @param  ?string $value Pass `null` to remove the cookie
-   * @throws lang.IllegalArgumentException if value contains control characters or a semicolon
    */
   public function __construct($name, $value) {
     $this->name= $name;
@@ -35,8 +34,6 @@ class Cookie implements Value {
       $this->value= '';
       $this->expires= time() - 86400 * 365;
       $this->maxAge= 0;
-    } else if (preg_match('/[\x00-\x1F;]/', $value)) {
-      throw new IllegalArgumentException('Cookie values cannot contain control characters or semicolons');
     } else {
       $this->value= $value;
     }

--- a/src/main/php/web/Cookie.class.php
+++ b/src/main/php/web/Cookie.class.php
@@ -1,6 +1,6 @@
 <?php namespace web;
 
-use lang\Value;
+use lang\{Value, IllegalArgumentException};
 use util\{Date, TimeSpan};
 
 /**
@@ -28,8 +28,13 @@ class Cookie implements Value {
    *
    * @param  string $name
    * @param  ?string $value Pass `null` to remove the cookie
+   * @throws lang.IllegalArgumentException if the cookie name contains illegal characters
    */
   public function __construct($name, $value) {
+    if (strcspn($name, "=,; \t\r\n\013\014") < strlen($name)) {
+      throw new IllegalArgumentException('Cookie names cannot contain any of [=,; \t\r\n\013\014]');
+    }
+
     $this->name= $name;
     if (null === $value) {
       $this->value= '';

--- a/src/main/php/web/Cookie.class.php
+++ b/src/main/php/web/Cookie.class.php
@@ -1,6 +1,6 @@
 <?php namespace web;
 
-use lang\{IllegalArgumentException, Value};
+use lang\Value;
 use util\{Date, TimeSpan};
 
 /**

--- a/src/main/php/web/Cookie.class.php
+++ b/src/main/php/web/Cookie.class.php
@@ -26,7 +26,7 @@ class Cookie implements Value {
    * Creates a new cookie
    *
    * @param  string $name
-   * @param  string $value Pass `null` to remove the cookie
+   * @param  ?string $value Pass `null` to remove the cookie
    * @throws lang.IllegalArgumentException if value contains control characters or a semicolon
    */
   public function __construct($name, $value) {

--- a/src/main/php/web/Request.class.php
+++ b/src/main/php/web/Request.class.php
@@ -239,7 +239,7 @@ class Request implements Value {
       if ($header= $this->header('Cookie')) {
         foreach (explode(';', $header) as $cookie) {
           sscanf(ltrim($cookie), '%[^=]=%[^;]', $name, $value);
-          $this->cookies[urldecode($name)]= urldecode($value);
+          $this->cookies[rawurldecode($name)]= rawurldecode($value);
         }
       }
     }

--- a/src/main/php/web/Request.class.php
+++ b/src/main/php/web/Request.class.php
@@ -239,7 +239,7 @@ class Request implements Value {
       if ($header= $this->header('Cookie')) {
         foreach (explode(';', $header) as $cookie) {
           sscanf(ltrim($cookie), '%[^=]=%[^;]', $name, $value);
-          $this->cookies[rawurldecode($name)]= rawurldecode($value);
+          $this->cookies[$name]= rawurldecode($value);
         }
       }
     }

--- a/src/test/php/web/unittest/CookieTest.class.php
+++ b/src/test/php/web/unittest/CookieTest.class.php
@@ -89,6 +89,14 @@ class CookieTest extends TestCase {
   }
 
   #[Test]
+  public function spaces_in_value_get_encoded() {
+    $this->assertEquals(
+      'name=value%20with%20spaces; SameSite=Lax; HttpOnly',
+      (new Cookie('name', 'value with spaces'))->header()
+    );
+  }
+
+  #[Test]
   public function setting_max_age_to_zero() {
     $this->assertEquals(
       'name=value; Max-Age=0; SameSite=Lax; HttpOnly',

--- a/src/test/php/web/unittest/CookieTest.class.php
+++ b/src/test/php/web/unittest/CookieTest.class.php
@@ -12,16 +12,6 @@ class CookieTest extends TestCase {
     new Cookie('name', 'value');
   }
 
-  #[Test, Expect(IllegalArgumentException::class)]
-  public function cannot_create_with_control_character() {
-    new Cookie('name', "\x00");
-  }
-
-  #[Test, Expect(IllegalArgumentException::class)]
-  public function cannot_create_with_semicolon() {
-    new Cookie('name', ';');
-  }
-
   #[Test]
   public function name() {
     $this->assertEquals('name', (new Cookie('name', 'value'))->name());
@@ -93,6 +83,22 @@ class CookieTest extends TestCase {
     $this->assertEquals(
       'name=%22val%C3%BCe%22%20with%20spaces; SameSite=Lax; HttpOnly',
       (new Cookie('name', '"valüe" with spaces'))->header()
+    );
+  }
+
+  #[Test]
+  public function control_character_in_value_gets_encoded() {
+    $this->assertEquals(
+      'name=a%00; SameSite=Lax; HttpOnly',
+      (new Cookie('name', "a\0"))->header()
+    );
+  }
+
+  #[Test]
+  public function semicolon_in_value_gets_encoded() {
+    $this->assertEquals(
+      'name=a%3B; SameSite=Lax; HttpOnly',
+      (new Cookie('name', 'a;'))->header()
     );
   }
 

--- a/src/test/php/web/unittest/CookieTest.class.php
+++ b/src/test/php/web/unittest/CookieTest.class.php
@@ -89,10 +89,10 @@ class CookieTest extends TestCase {
   }
 
   #[Test]
-  public function spaces_in_value_get_encoded() {
+  public function characters_in_value_get_encoded() {
     $this->assertEquals(
-      'name=value%20with%20spaces; SameSite=Lax; HttpOnly',
-      (new Cookie('name', 'value with spaces'))->header()
+      'name=%22val%C3%BCe%22%20with%20spaces; SameSite=Lax; HttpOnly',
+      (new Cookie('name', '"valüe" with spaces'))->header()
     );
   }
 

--- a/src/test/php/web/unittest/CookieTest.class.php
+++ b/src/test/php/web/unittest/CookieTest.class.php
@@ -17,6 +17,11 @@ class CookieTest extends TestCase {
     $this->assertEquals('name', (new Cookie('name', 'value'))->name());
   }
 
+  #[Test, Expect(IllegalArgumentException::class), Values(["=", ",", ";", " ", "\t", "\r", "\n", "\013", "\014"])]
+  public function name_cannot_contain($char) {
+    new Cookie('name'.$char, 'value');
+  }
+
   #[Test]
   public function value() {
     $this->assertEquals('value', (new Cookie('name', 'value'))->value());

--- a/src/test/php/web/unittest/RequestTest.class.php
+++ b/src/test/php/web/unittest/RequestTest.class.php
@@ -221,6 +221,14 @@ class RequestTest extends TestCase {
     );
   }
 
+  #[Test]
+  public function cookie_value_decoded() {
+    $this->assertEquals(
+      '"valüe" with spaces',
+      (new Request(new TestInput('GET', '/', ['Cookie' => 'test=%22val%C3%BCe%22%20with%20spaces'])))->cookie('test')
+    );
+  }
+
   #[Test, Values([0, 8192, 10000])]
   public function stream_with_content_length($length) {
     $body= str_repeat('A', $length);


### PR DESCRIPTION
> The cookie value string can use encodeURIComponent() to ensure that the string does not contain any commas, semicolons, or whitespace (which are disallowed in cookie values).

Source: https://developer.mozilla.org/en-US/docs/Web/API/document/cookie

This is in line with what PHP and ExpressJS do.
