### PR TITLE
Application initialization

### DIFF
--- a/src/main/php/web/Application.class.php
+++ b/src/main/php/web/Application.class.php
@@ -1,11 +1,13 @@
 <?php namespace web;
 
+use lang\Value;
+
 /**
  * Application is at the heart at every web project.
  *
  * @test  xp://web.unittest.ApplicationTest
  */
-abstract class Application implements \lang\Value {
+abstract class Application implements Value {
   private $routing= null;
   protected $environment;
 
@@ -31,6 +33,16 @@ abstract class Application implements \lang\Value {
       $this->routing= Routing::cast($this->routes(), true);
     }
     return $this->routing;    
+  }
+
+  /**
+   * Initializes this application, being run once when the server starts.
+   * Empty in this default implementation, overwrite in subclasses.
+   *
+   * @return void
+   */
+  public function initialize() {
+    // Empty
   }
 
   /**

--- a/src/main/php/xp/web/srv/Develop.class.php
+++ b/src/main/php/xp/web/srv/Develop.class.php
@@ -5,7 +5,7 @@ use lang\archive\ArchiveClassLoader;
 use lang\{ClassLoader, CommandLine, FileSystemClassLoader, Runtime, RuntimeOptions};
 use peer\Socket;
 use util\cmd\Console;
-use web\Logging;
+use web\{Application, Environment, Logging};
 
 class Develop extends Server {
 
@@ -21,6 +21,9 @@ class Develop extends Server {
    * @param  string[] $logging
    */
   public function serve($source, $profile, $webroot, $docroot, $config, $args, $logging) {
+    $environment= new Environment($profile, $webroot, $docroot, $config, $args, $logging);
+    $application= (new Source($source, $environment))->application($args);
+    $application->initialize();
 
     // PHP doesn't start with a nonexistant document root
     if (!$docroot->exists()) {

--- a/src/main/php/xp/web/srv/Develop.class.php
+++ b/src/main/php/xp/web/srv/Develop.class.php
@@ -6,6 +6,7 @@ use lang\{ClassLoader, CommandLine, FileSystemClassLoader, Runtime, RuntimeOptio
 use peer\Socket;
 use util\cmd\Console;
 use web\{Application, Environment, Logging};
+use xp\web\Source;
 
 class Develop extends Server {
 
@@ -63,9 +64,8 @@ class Develop extends Server {
     putenv('WEB_LOG='.$logging);
 
     Console::writeLine("\e[33m@", nameof($this), "(HTTP @ `php ", implode(' ', $arguments), "`)\e[0m");
-    Console::writeLine("\e[1mServing {$profile}:", $source, $config, "\e[0m > ", Logging::of($logging)->target());
+    Console::writeLine("\e[1mServing {$profile}:", $application, $config, "\e[0m > ", $environment->logging()->target());
     Console::writeLine("\e[36m", str_repeat('═', 72), "\e[0m");
-    Console::writeLine();
 
     if ('WINDOWS' === $os->name()) {
       $nul= 'NUL';

--- a/src/main/php/xp/web/srv/Standalone.class.php
+++ b/src/main/php/xp/web/srv/Standalone.class.php
@@ -56,6 +56,7 @@ class Standalone extends Server {
   public function serve($source, $profile, $webroot, $docroot, $config, $args, $logging) {
     $environment= new Environment($profile, $webroot, $docroot, $config, $args, $logging);
     $application= (new Source($source, $environment))->application($args);
+    $application->initialize();
     $application->routing();
 
     $socket= new ServerSocket($this->host, $this->port);

--- a/src/test/php/web/unittest/ResponseTest.class.php
+++ b/src/test/php/web/unittest/ResponseTest.class.php
@@ -119,7 +119,7 @@ class ResponseTest {
     $res= new Response(new TestOutput());
     $res->cookie(new Cookie('theme', 'light'));
     $res->cookie(new Cookie('theme', 'dark'));
-    $this->assertEquals(['dark'], array_map(function($c) { return $c->value(); }, $res->cookies()));
+    Assert::equals(['dark'], array_map(function($c) { return $c->value(); }, $res->cookies()));
   }
 
   #[Test]
@@ -127,7 +127,7 @@ class ResponseTest {
     $res= new Response(new TestOutput());
     $res->cookie(new Cookie('theme', 'light'));
     $res->cookie(new Cookie('theme', 'dark'), true);
-    $this->assertEquals(['light', 'dark'], array_map(function($c) { return $c->value(); }, $res->cookies()));
+    Assert::equals(['light', 'dark'], array_map(function($c) { return $c->value(); }, $res->cookies()));
   }
 
   #[Test]


### PR DESCRIPTION
This PR adds an `initialize()` method to `web.Application` which is run once when the server starts. See #52 

```php
use web\Application;

class Hello extends Application {

  public function initialize() {
    // Perform database migration, wait for dependant services to
    // launch in their Docker containers, etcetera.
  }

  public function routes() {
    return [
      '/' => function($req, $res) {
        $res->answer(200, 'OK');
        $res->send('Hello World', 'text/plain');
      },
    ];
  }
}