### PR TITLE
File upload transmission

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,22 +166,18 @@ $handler= function($req, $res) use($uploads) {
       $res->hint(100, 'Continue');
     }
 
-    // Upload files, yielding control back to the server after each file
-    // so that other clients' requests are not blocked.
+    // Transmit files to uploads directory asynchronously
     $files= [];
     $bytes= 0;
     foreach ($multipart->files() as $name => $file) {
       $files[]= $name;
-      $bytes+= $file->transfer($uploads);
-      yield;
+      $bytes+= yield from $file->transmit($uploads);
     }
 
     // Do something with files and bytes...
   }
 };
 ```
-
-*If you expect bigger file uploads, you can use `$file` as an `io.streams.InputStream` and yield control more often.*
 
 Early hints
 -----------

--- a/src/main/php/web/Response.class.php
+++ b/src/main/php/web/Response.class.php
@@ -216,8 +216,8 @@ class Response {
     $out= $this->stream($size);
     try {
       while ($in->available()) {
+        yield 'write' => $out;
         $out->write($in->read());
-        yield;
       }
     } finally {
       $out->close();

--- a/src/main/php/web/handler/FilesFrom.class.php
+++ b/src/main/php/web/handler/FilesFrom.class.php
@@ -67,19 +67,19 @@ class FilesFrom implements Handler {
   /**
    * Copies a given amount of bytes from the specified file to the output
    *
-   * @param  web.io.Output $output
+   * @param  web.io.Output $out
    * @param  io.File $file
    * @param  web.io.Range $range
    * @return iterable
    */
-  private function copy($output, $file, $range) {
+  private function copy($out, $file, $range) {
     $file->seek($range->start());
 
     $length= $range->length();
     while ($length && $chunk= $file->read(min(self::CHUNKSIZE, $length))) {
-      $output->write($chunk);
+      yield 'write' => $out;
+      $out->write($chunk);
       $length-= strlen($chunk);
-      yield;
     }
   }
 
@@ -129,8 +129,8 @@ class FilesFrom implements Handler {
         $file->open(File::READ);
         try {
           do {
+            yield 'write' => $out;
             $out->write($file->read(self::CHUNKSIZE));
-            yield;
           } while (!$file->eof());
         } finally {
           $file->close();

--- a/src/main/php/web/io/Incomplete.class.php
+++ b/src/main/php/web/io/Incomplete.class.php
@@ -53,12 +53,23 @@ class Incomplete extends Part implements InputStream {
   /**
    * Transfers this stream to a given target.
    *
+   * @deprecated Use `yield from $stream->transmit(...)` instead!
    * @param  io.Path|io.Folder|io.streams.OutputStream|string $target
    * @return int Number of bytes written
    * @throws lang.IllegalArgumentException if filename is invalid
    * @throws io.IOException
    */
   public function transfer($target) { throw $this->notSupported(); }
+
+  /**
+   * Transmits this stream to a given target.
+   *
+   * @param  io.Path|io.Folder|io.streams.OutputStream|string $target
+   * @return iterable
+   * @throws lang.IllegalArgumentException if filename is invalid
+   * @throws io.IOException
+   */
+  public function transmit($target) { throw $this->notSupported(); yield; }
 
   /** @return int */
   public function available() { throw $this->notSupported(); }

--- a/src/main/php/web/io/Parts.class.php
+++ b/src/main/php/web/io/Parts.class.php
@@ -58,11 +58,13 @@ class Parts implements IteratorAggregate {
       // Yield chunks as long as no "\r" is encountered
       while (false === ($p= strpos($this->buffer, "\r")) && $this->in->available()) {
         yield $this->buffer;
+        yield null;
         $this->buffer= $this->in->read(8192);
       }
 
       // Found beginning of delimiter, read enough bytes to be able to decide
       while ($p + $n >= strlen($this->buffer) && $this->in->available()) {
+        yield null;
         $this->buffer.= $this->in->read(8192);
       }
 

--- a/src/main/php/web/io/Stream.class.php
+++ b/src/main/php/web/io/Stream.class.php
@@ -98,6 +98,8 @@ class Stream extends Part implements InputStream {
     try {
       $written= 0;
       foreach ($this->chunks as $chunk) {
+        if (null === $chunk) continue;
+
         $out->write($chunk);
         $written+= strlen($chunk);
       }
@@ -134,11 +136,13 @@ class Stream extends Part implements InputStream {
 
     try {
       $written= 0;
-      yield 'read' => null;
       foreach ($this->chunks as $chunk) {
-        $out->write($chunk);
-        $written+= strlen($chunk);
-        yield 'read' => null;
+        if (null === $chunk) {
+          yield 'read' => null;
+        } else {
+          $out->write($chunk);
+          $written+= strlen($chunk);
+        }
       }
       return $written;
     } finally {
@@ -161,7 +165,7 @@ class Stream extends Part implements InputStream {
     if ($this->chunks->valid()) {
       $bytes= $this->chunks->current();
       $this->chunks->next();
-      return $bytes;
+      return (string)$bytes;
     }
 
     return null;

--- a/src/main/php/web/io/Stream.class.php
+++ b/src/main/php/web/io/Stream.class.php
@@ -72,6 +72,7 @@ class Stream extends Part implements InputStream {
   /**
    * Transfers this stream to a given target.
    *
+   * @deprecated Use `yield from $stream->transmit(...)` instead!
    * @param  io.Path|io.Folder|io.streams.OutputStream|string $target
    * @return int Number of bytes written
    * @throws lang.IllegalArgumentException if filename is invalid
@@ -99,6 +100,45 @@ class Stream extends Part implements InputStream {
       foreach ($this->chunks as $chunk) {
         $out->write($chunk);
         $written+= strlen($chunk);
+      }
+      return $written;
+    } finally {
+      $out->close();
+    }
+  }
+
+  /**
+   * Transmits this stream to a given target.
+   *
+   * @param  io.Path|io.Folder|io.streams.OutputStream|string $target
+   * @return iterable
+   * @throws lang.IllegalArgumentException if filename is invalid
+   * @throws io.IOException
+   */
+  public function transmit($target) {
+    if ($target instanceof OutputStream) {
+      $out= $target;
+    } else if ($target instanceof File) {
+      $out= $target->out();
+    } else if ($target instanceof Folder) {
+      $out= new FileOutputStream(new File($target, $this->name()));
+    } else if (null === $target) {
+      throw new IllegalArgumentException('Invalid filename <null>');
+    } else if (is_string($target) && (0 === strlen($target) || false !== strpos($target, "\0"))) {
+      throw new IllegalArgumentException('Invalid filename "'.addcslashes($target, "\0..\37!\177..\377").'"');
+    } else if (is_dir($target)) {
+      $out= new FileOutputStream(new File($target, $this->name()));
+    } else {
+      $out= new FileOutputStream($target);
+    }
+
+    try {
+      $written= 0;
+      yield 'read' => null;
+      foreach ($this->chunks as $chunk) {
+        $out->write($chunk);
+        $written+= strlen($chunk);
+        yield 'read' => null;
       }
       return $written;
     } finally {

--- a/src/main/php/xp/web/Upload.class.php
+++ b/src/main/php/xp/web/Upload.class.php
@@ -102,6 +102,50 @@ class Upload extends Part implements InputStream {
     return $file->size();
   }
 
+  /**
+   * Transfers this stream to a given target.
+   *
+   * @param  io.Path|io.Folder|io.streams.OutputStream|string $target
+   * @return iterable
+   * @throws lang.IllegalArgumentException if filename is invalid
+   * @throws io.IOException
+   */
+  public function transmit($target) {
+
+    // If we are passed a stream, transfer the source file's contents
+    if ($target instanceof OutputStream) {
+      $this->handle= new File($this->source);
+      $this->handle->open(File::READ);
+
+      $written= 0;
+      do {
+        yield;
+        $chunk= $this->handle->read();
+        $target->write($chunk);
+        $written+= strlen($chunk);
+      } while (!$this->handle->eof());
+
+      return $written;
+    }
+
+    // Use filesystem I/O to move the already stored file
+    $file= new File($this->source);
+    if ($target instanceof File) {
+      $to= $target;
+    } else if ($target instanceof Folder) {
+      $to= new File($target, $this->name());
+    } else if (is_string($target) && (0 === strlen($target) || false !== strpos($target, "\0"))) {
+      throw new IllegalArgumentException('Invalid filename "'.addcslashes($target, "\0..\37!\177..\377").'"');
+    } else if (is_dir($target)) {
+      $to= new File($target, $this->name());
+    } else {
+      $to= new File($target);
+    }
+
+    $file->move($to);
+    return $file->size();
+  }
+
   /** @return int */
   public function available() {
     if (null === $this->handle) {

--- a/src/main/php/xp/web/srv/Input.class.php
+++ b/src/main/php/xp/web/srv/Input.class.php
@@ -3,9 +3,9 @@
 use lang\FormatException;
 use peer\CryptoSocket;
 use web\Headers;
-use web\io\{ReadChunks, ReadLength, Parts, Input as IOInput};
+use web\io\{ReadChunks, ReadLength, Parts, Input as Base};
 
-class Input implements IOInput {
+class Input implements Base {
   const CLOSE   = 0;
   const REQUEST = 1;
 

--- a/src/main/php/xp/web/srv/Output.class.php
+++ b/src/main/php/xp/web/srv/Output.class.php
@@ -1,8 +1,8 @@
 <?php namespace xp\web\srv;
 
-use web\io\{Buffered, WriteChunks};
+use web\io\{Buffered, WriteChunks, Output as Base};
 
-class Output extends \web\io\Output {
+class Output extends Base {
   private $socket, $version;
 
   /**

--- a/src/test/php/web/unittest/io/IncompleteTest.class.php
+++ b/src/test/php/web/unittest/io/IncompleteTest.class.php
@@ -35,8 +35,11 @@ class IncompleteTest {
   }
 
   #[Test, Expect(OperationNotSupportedException::class)]
-  public function cannot_transfer() {
-    (new Incomplete('upload', UPLOAD_ERR_INI_SIZE))->transfer('./uploads');
+  public function cannot_transmit() {
+    $it= (new Incomplete('upload', UPLOAD_ERR_INI_SIZE))->transmit('./uploads');
+    while ($it->valid()) {
+      $it->next();
+    }
   }
 
   #[Test, Expect(OperationNotSupportedException::class)]

--- a/src/test/php/web/unittest/io/StreamTest.class.php
+++ b/src/test/php/web/unittest/io/StreamTest.class.php
@@ -16,9 +16,7 @@ class StreamTest extends TestCase {
    * @return iterable
    */
   private function asIterable(... $chunks) {
-    foreach ($chunks as $chunk) {
-      yield $chunk;
-    }
+    yield from $chunks;
   }
 
   /**
@@ -62,6 +60,7 @@ class StreamTest extends TestCase {
     yield [[], ''];
     yield [['Test'], 'Test'];
     yield [['Test', 'ed'], 'Tested'];
+    yield [['Test', null, 'ed'], 'Tested'];
   }
 
   /** @return iterable */


### PR DESCRIPTION
This pull request introduces a `transmit()` method for file uploads to replace the *transfer()* method, making uploads consistent with [downloads](https://github.com/xp-forge/web/pull/73).

## Example
Given the following file upload code:

```php
$uploads= new Folder(...);
$handler= function($req, $res) use($uploads) {
  if ($multipart= $req->multipart()) {
    if ('100-continue' === $req->header('Expect')) $res->hint(100, 'Continue');

    $files= [];
    $bytes= 0;
    foreach ($multipart->files() as $name => $file) {
      $files[]= $name;
      $bytes+= $file->transfer($uploads);
    }

    // Do something with files and bytes...
  }
};
```

The problem is that all other requests are blocked until all uploads have been processed. By adding a *yield* statement after `$file->transfer($uploads);`, we could hand back control to the server once a file has been transferred (*which is what README suggested*):

```diff
 foreach ($multipart->files() as $name => $file) {
   $files[]= $name;
   $bytes+= $file->transfer($uploads);
+  yield;
 }
```

However, with big file uploads (or clients with slow connection speeds), this might still be blocking other requests for a significant amount of time. With the new API, the example can be changed as follows:

```diff
 foreach ($multipart->files() as $name => $file) {
   $files[]= $name;
-  $bytes+= $file->transfer($uploads);
+  $bytes+= yield from $file->transmit($uploads);
 }
```

## Further notes

This pull request makes use of the new features added in xp-framework/networking#22. However, the code also runs without this featureset being available!