### PR TITLE
Allow passing or removing environment variables

### DIFF
--- a/src/main/php/web/Environment.class.php
+++ b/src/main/php/web/Environment.class.php
@@ -91,7 +91,7 @@ class Environment {
    * @param  ?string $value
    * @return self
    */
-  public function with($name, $value) {
+  public function export($name, $value) {
     if (null === $value) {
       putenv($name);
     } else {

--- a/src/main/php/web/Environment.class.php
+++ b/src/main/php/web/Environment.class.php
@@ -84,6 +84,23 @@ class Environment {
   }
 
   /**
+   * Pass a given environment variable and value. Pass NULL in value to
+   * remove this environment variable.
+   *
+   * @param  string $name
+   * @param  ?string $value
+   * @return self
+   */
+  public function with($name, $value) {
+    if (null === $value) {
+      putenv($name);
+    } else {
+      putenv($name.'='.$value);
+    }
+    return $this;
+  }
+
+  /**
    * Gets properties
    *
    * @param  string $name

--- a/src/test/php/web/unittest/EnvironmentTest.class.php
+++ b/src/test/php/web/unittest/EnvironmentTest.class.php
@@ -51,12 +51,12 @@ class EnvironmentTest {
 
   #[Test, Values(['abc', ''])]
   public function set_variable($value) {
-    $this->assertEquals($value, (new Environment('dev', '.', 'static', []))->export('test', $value)->variable('test'));
+    Assert::equals($value, (new Environment('dev', '.', 'static', []))->export('test', $value)->variable('test'));
   }
 
   #[Test]
   public function unset_variable() {
-    $this->assertNull((new Environment('dev', '.', 'static', []))->export('test', null)->variable('test'));
+    Assert::null((new Environment('dev', '.', 'static', []))->export('test', null)->variable('test'));
   }
 
   #[Test]

--- a/src/test/php/web/unittest/EnvironmentTest.class.php
+++ b/src/test/php/web/unittest/EnvironmentTest.class.php
@@ -51,12 +51,12 @@ class EnvironmentTest extends TestCase {
 
   #[Test, Values(['abc', ''])]
   public function set_variable($value) {
-    $this->assertEquals($value, (new Environment('dev', '.', 'static', []))->with('test', $value)->variable('test'));
+    $this->assertEquals($value, (new Environment('dev', '.', 'static', []))->export('test', $value)->variable('test'));
   }
 
   #[Test]
   public function unset_variable() {
-    $this->assertNull((new Environment('dev', '.', 'static', []))->with('test', null)->variable('test'));
+    $this->assertNull((new Environment('dev', '.', 'static', []))->export('test', null)->variable('test'));
   }
 
   #[Test]

--- a/src/test/php/web/unittest/EnvironmentTest.class.php
+++ b/src/test/php/web/unittest/EnvironmentTest.class.php
@@ -49,6 +49,16 @@ class EnvironmentTest extends TestCase {
     $this->assertEquals('abc', (new Environment('dev', '.', 'static', []))->variable('XP_TEST'));
   }
 
+  #[Test, Values(['abc', ''])]
+  public function set_variable($value) {
+    $this->assertEquals($value, (new Environment('dev', '.', 'static', []))->with('test', $value)->variable('test'));
+  }
+
+  #[Test]
+  public function unset_variable() {
+    $this->assertNull((new Environment('dev', '.', 'static', []))->with('test', null)->variable('test'));
+  }
+
   #[Test]
   public function tempDir() {
     $this->assertTrue(is_dir((new Environment('dev', '.', 'static', []))->tempDir()));


### PR DESCRIPTION
This pull request adds a `export()` method which modifies environment variables (access via `$env->variable($name)`.

## Usage

```php
// Set timezone in environment
$env->export('TZ', 'Europe/Berlin');

// New: Remove SECRET from environment
$env->export('SECRET', null);
```

## Example

```php
<?php namespace com\example\atlas;

use com\amazon\aws\lambda\HttpApi;

class Lambda extends HttpApi {

  public function routes($env) { return new App($env->export('runtime', 'aws')); }
}
```