### PR TITLE
Make web.Routing implement web.Handler

### DIFF
--- a/src/main/php/web/Application.class.php
+++ b/src/main/php/web/Application.class.php
@@ -22,9 +22,9 @@ abstract class Application implements \lang\Value {
   public function environment() { return $this->environment; }
 
   /**
-   * Returns routing, lazily initialized
+   * Returns routing handler, lazily initialized
    *
-   * @return web.Routing
+   * @return web.Handler
    */
   public final function routing() {
     if (null === $this->routing) {
@@ -39,7 +39,7 @@ abstract class Application implements \lang\Value {
    *
    * _Overwrite this in your implementation!_
    *
-   * @return web.Routing|[:var]
+   * @return web.Handler|function(web.Request, web.Response): var|[:var]
    */
   public abstract function routes();
 

--- a/src/main/php/web/Application.class.php
+++ b/src/main/php/web/Application.class.php
@@ -41,7 +41,7 @@ abstract class Application implements \lang\Value {
    *
    * @return web.Routing|[:var]
    */
-  protected abstract function routes();
+  public abstract function routes();
 
   /**
    * Installs global filters
@@ -50,18 +50,18 @@ abstract class Application implements \lang\Value {
    * @return void
    */
   public function install($filters) {
-    $this->routing= Routing::cast(new Filters($filters, $this->routing()), true);
+    $this->routing= new Filters($filters, $this->routing());
   }
 
   /**
-   * Service delegates to the routing, calling its `service()` method.
+   * Service delegates to the routing, calling its `handle()` method.
    *
    * @param  web.Request $request
    * @param  web.Response $response
    * @return var
    */
   public function service($request, $response) {
-    return $this->routing()->service($request, $response);
+    return $this->routing()->handle($request, $response);
   }
 
   /** @return string */

--- a/src/main/php/web/Filters.class.php
+++ b/src/main/php/web/Filters.class.php
@@ -6,8 +6,8 @@ use web\filters\Invocation;
  * Filters acts as a handler and invokes all filters before passing control
  * on to the given handler.
  *
- * @see   xp://web.Filter
- * @test  xp://web.unittest.FiltersTest
+ * @see   web.Filter
+ * @test  web.unittest.FiltersTest
  */
 class Filters implements Handler {
   private $routing;
@@ -17,7 +17,7 @@ class Filters implements Handler {
    * Creates a new instance
    *
    * @param  (web.Filter|function(web.Request, web.Response, web.filters.Invocation)[] $filters
-   * @param  [:web.Routing]|web.Routing $routing
+   * @param  web.Handler|function(web.Request, web.Response): var|[:var] $routing
    */
   public function __construct($filters, $routing) {
     foreach ($filters as $filter) {

--- a/src/main/php/web/Routing.class.php
+++ b/src/main/php/web/Routing.class.php
@@ -7,9 +7,9 @@ use web\routing\{CannotRoute, Matches, Path, Target};
  * Routing takes care of directing the request to the correct target
  * by using one or more routes given to it.
  *
- * @test  xp://web.unittest.RoutingTest
+ * @test  web.unittest.RoutingTest
  */
-class Routing {
+class Routing implements Handler {
   private $top= false;
   private $fallback= null;
   private $routes= [];
@@ -21,7 +21,7 @@ class Routing {
    * - A map of definitions => handlers, which are passed to `matching()`
    * - A handler, which becomes the argument to `fallback()`.
    *
-   * @param  self|[:var]|web.Handler|web.Application|function(web.Request, web.Response): var $routes
+   * @param  web.Handler|web.Application|function(web.Request, web.Response): var|[:var] $routes
    * @param  bool $top Whether this is the top-level routing
    * @return self
    */
@@ -133,13 +133,13 @@ class Routing {
   }
 
   /**
-   * Service a request
+   * Handle a request
    *
    * @param  web.Request $request
    * @param  web.Response $response
    * @return var
    */
-  public function service($request, $response) {
+  public function handle($request, $response) {
     $seen= [];
 
     dispatch: $result= $this->route($request)->handle($request, $response);
@@ -153,5 +153,10 @@ class Routing {
     }
 
     return $result;
+  }
+
+  /** @deprecated */
+  public function service($request, $response) {
+    return $this->handle($request, $response);
   }
 }

--- a/src/main/php/web/filters/Invocation.class.php
+++ b/src/main/php/web/filters/Invocation.class.php
@@ -1,11 +1,12 @@
 <?php namespace web\filters;
 
+use Generator, Traversable;
 use web\{Routing, Dispatch};
 
 /**
  * Filter chain invocation
  *
- * @test  xp://web.unittest.filters.InvocationTest
+ * @test  web.unittest.filters.InvocationTest
  */
 class Invocation {
   private $routing, $filters, $offset, $length;
@@ -13,7 +14,7 @@ class Invocation {
   /**
    * Create a new Invocation
    *
-   * @param  web.Routing|[:var]|web.Handler|function(web.Request, web.Response): var $routes
+   * @param  web.Handler|function(web.Request, web.Response): var|[:var] $routing
    * @param  web.Filter[] $filters
    */
   public function __construct($routing, $filters= []) {
@@ -36,11 +37,7 @@ class Invocation {
     }
 
     // Ensure the results of service invocation are iterable
-    $return= $this->routing->service($request, $response);
-    if ($return instanceof \Generator || $return instanceof \Traversable) {
-      return $return;
-    } else {
-      return (array)$return;
-    }
+    $return= $this->routing->handle($request, $response);
+    return $return instanceof Traversable ? $return : (array)$return;
   }
 }

--- a/src/test/php/web/unittest/FiltersTest.class.php
+++ b/src/test/php/web/unittest/FiltersTest.class.php
@@ -10,7 +10,7 @@ class FiltersTest extends TestCase {
    * Handle filters
    *
    * @param  web.Filter|function(web.Request, web.Response, web.filters.Invocation): var $filter
-   * @param  web.Handler|function(web.Request, web.Response): var $handler
+   * @param  web.Handler|function(web.Request, web.Response): var|[:var] $handler
    * @return web.Response
    */
   private function filter($filter, $handler) {
@@ -42,6 +42,15 @@ class FiltersTest extends TestCase {
     $this->filter(null, function($req, $res) use(&$invoked) {
       $invoked[]= $req->method().' '.$req->uri()->path();
     });
+    $this->assertEquals(['GET /'], $invoked);
+  }
+
+  #[Test]
+  public function runs_handlers() {
+    $invoked= [];
+    $this->filter(null, ['/' => function($req, $res) use(&$invoked) {
+      $invoked[]= $req->method().' '.$req->uri()->path();
+    }]);
     $this->assertEquals(['GET /'], $invoked);
   }
 

--- a/src/test/php/web/unittest/RoutingTest.class.php
+++ b/src/test/php/web/unittest/RoutingTest.class.php
@@ -22,8 +22,8 @@ class RoutingTest extends TestCase {
   }
 
   #[Test, Expect(CannotRoute::class)]
-  public function cannot_service_by_default() {
-    (new Routing())->service(new Request(new TestInput('GET', '/')), new Response());
+  public function cannot_handle_by_default() {
+    (new Routing())->handle(new Request(new TestInput('GET', '/')), new Response());
   }
 
   #[Test]


### PR DESCRIPTION
This way, we can rewrite the following:

## Current code

```php
$auth= new SessionBased(...);
return [
  '/avatar' => $auth->required(function($req, $res) { ... }), 
  '/'       => $auth->required(function($req, $res) { ... }),
];
```
(continues to work)

## New code

```php
$auth= new SessionBased(...);
return $auth->required([
  '/avatar' => function($req, $res) { ... }, 
  '/'       => function($req, $res) { ... },
]);
```
