### PR TITLE
Allow calling install() from within routing

### DIFF
--- a/src/main/php/web/Route.class.php
+++ b/src/main/php/web/Route.class.php
@@ -10,7 +10,7 @@ class Route {
    * Creates a new route
    *
    * @param  web.routing.Match|function(web.Request): web.Handler $match
-   * @param  web.Handler|function(web.Request, web.Response): var $handler
+   * @param  web.Handler|function(web.Request, web.Response): var|[:var] $handler
    */
   public function __construct($match, $handler) {
     if ($match instanceof RouteMatch) {
@@ -21,6 +21,8 @@ class Route {
 
     if ($handler instanceof Handler) {
       $this->handler= $handler;
+    } else if (is_array($handler)) {
+      $this->handler= Routing::cast($handler);
     } else {
       $this->handler= new Call($handler);
     }

--- a/src/test/php/web/unittest/RoutingTest.class.php
+++ b/src/test/php/web/unittest/RoutingTest.class.php
@@ -3,7 +3,7 @@
 use unittest\{Expect, Test, TestCase, Values};
 use web\io\{TestInput, TestOutput};
 use web\routing\{CannotRoute, Target};
-use web\{Application, Environment, Handler, Request, Response, Route, Routing};
+use web\{Application, Environment, Filters, Handler, Request, Response, Route, Routing};
 
 class RoutingTest extends TestCase {
   private $handlers;
@@ -12,7 +12,8 @@ class RoutingTest extends TestCase {
   public function setUp() {
     $this->handlers= [
       'specific' => new class() implements Handler { public $name= 'specific'; public function handle($req, $res) { }},
-      'default'  => new class() implements Handler { public $name= 'default'; public function handle($req, $res) { }}
+      'default'  => new class() implements Handler { public $name= 'default'; public function handle($req, $res) { }},
+      'error'    => new class() implements Handler { public $name= 'error'; public function handle($req, $res) { }},
     ];
   }
 


### PR DESCRIPTION
Previously, this would result in an endless loop, the `install()` call would need to be moved to the constructor.

## Example

```php
<?php namespace de\thekid\dialog;

use web\filters\BehindProxy;
use web\Application;

class App extends Application {

  /** Returns routing for this web application */
  public function routes() {

    // If behind a proxy, use an environment variable to rewrite the request URI
    if ($service= $this->environment->variable('SERVICE')) {
      $this->install(new BehindProxy([$service => '/']));
    }

    return [...];
  }
}
```