### PR TITLE
Catch socket I/O errors and log them in a less-verbose manner

### DIFF
--- a/src/main/php/xp/web/srv/CannotWrite.class.php
+++ b/src/main/php/xp/web/srv/CannotWrite.class.php
@@ -1,0 +1,9 @@
+<?php namespace xp\web\srv;
+
+use io\IOException;
+
+class CannotWrite extends IOException {
+
+  /** @return string */
+  public function toString(): string { return '// '.$this->message; }
+}

--- a/src/main/php/xp/web/srv/HttpProtocol.class.php
+++ b/src/main/php/xp/web/srv/HttpProtocol.class.php
@@ -140,6 +140,8 @@ class HttpProtocol implements ServerProtocol {
         $this->logging->log($request, $response);
       } catch (Error $e) {
         $this->sendError($request, $response, $e);
+      } catch (CannotWrite $e) {
+        $this->logging->log($request, $response, $e);
       } catch (\Throwable $e) {
         $this->sendError($request, $response, new InternalServerError($e));
       } finally {

--- a/src/main/php/xp/web/srv/Output.class.php
+++ b/src/main/php/xp/web/srv/Output.class.php
@@ -1,5 +1,6 @@
 <?php namespace xp\web\srv;
 
+use peer\SocketException;
 use web\io\{Buffered, WriteChunks, Output as Base};
 
 class Output extends Base {
@@ -51,6 +52,15 @@ class Output extends Base {
    * @return void
    */
   public function write($bytes) {
-    $this->socket->write($bytes);
+    try {
+      $this->socket->write($bytes);
+    } catch (SocketException $e) {
+
+      // See how the SocketException error message is constructed in Socket::write() at
+      // https://github.com/xp-framework/networking/blob/v10.4.0/src/main/php/peer/Socket.class.php#L359
+      $message= $e->getMessage();
+      $p= strpos($message, ': ');
+      throw new CannotWrite(false === $p ? $message : substr($message, $p + 2), $e);
+    }
   }
 }

--- a/src/main/php/xp/web/srv/Output.class.php
+++ b/src/main/php/xp/web/srv/Output.class.php
@@ -56,7 +56,13 @@ class Output extends Base {
       $this->socket->write($bytes);
     } catch (SocketException $e) {
 
-      // See how the SocketException error message is constructed in Socket::write() at
+      // Caused by the client shutting down communications, and doesn't indicate an
+      // error on our side! This happens regularily when browsers read video meta data
+      // to be able to determine the video length - so they simply read until enough
+      // data is available, then close the connection. In any case, there's nothing
+      // we can do at this point to signal the error to the client!
+      //
+      // Extract the cause; see how the SocketException error message is constructed at
       // https://github.com/xp-framework/networking/blob/v10.4.0/src/main/php/peer/Socket.class.php#L359
       $message= $e->getMessage();
       $p= strpos($message, ': ');


### PR DESCRIPTION
This pull request catches I/O errors from writing to the response *after having sent the headers* and displays a notice in the logfile rather than a complete stack trace.

### Before

![Before](https://user-images.githubusercontent.com/696742/202850553-abdf151d-5efa-478b-a589-9550f2568299.png)

### After

![After](https://user-images.githubusercontent.com/696742/202850515-120f328d-1b88-4977-82b4-ce7ea51f4d69.png)

See #97 //cc @mikey179
