### PR TITLE
Migrate to new testing library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         echo "vendor/autoload.php" > composer.pth
 
     - name: Run test suite
-      run: sh xp-run xp.unittest.TestRunner src/test/php
+      run: sh xp-run xp.test.Runner src/test/php
 
     - name: Run integration tests
-      run: sh xp-run xp.unittest.TestRunner src/it/php
+      run: sh xp-run xp.test.Runner src/it/php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,6 @@ jobs:
         extensions: com_dotnet
         ini-values: date.timezone=Europe/Berlin
 
-    - name: Setup Problem Matchers for PHP
-      run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-
     - name: Validate composer.json and composer.lock
       run: composer validate
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=7.0.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^11.0 | ^10.1"
+    "xp-framework/test": "^1.0"
   },
   "bin": ["bin/xp.xp-forge.web"],
   "autoload" : {

--- a/src/it/php/web/unittest/IntegrationTest.class.php
+++ b/src/it/php/web/unittest/IntegrationTest.class.php
@@ -1,21 +1,26 @@
 <?php namespace web\unittest;
 
-use unittest\{Assert, Action, Test, Values};
+use test\{Assert, After, Test, Values};
 
-#[Action(eval: 'new StartServer("web.unittest.TestingServer", "connected")')]
+#[StartServer(TestingServer::class)]
 class IntegrationTest {
   const FORM_URLENCODED = 'application/x-www-form-urlencoded';
 
-  private static $connection;
+  private $server;
 
-  /** @param peer.Socket $client */
-  public static function connected($client) {
-    self::$connection= $client;
+  /** @param web.unittest.StartServer $server */
+  public function __construct($server) {
+    $this->server= $server;
+  }
+
+  #[After]
+  public function shutdown() {
+    $this->server->shutdown();
   }
 
   /**
-   * Sends a request. Ensure connection is closed for receive() to be able
-   * to read until EOF.
+   * Sends a request. Opens connection before sending the request, and closes
+   * connection after reading the response.
    *
    * @param  string $method
    * @param  string $uri
@@ -25,139 +30,135 @@ class IntegrationTest {
    * @return void
    */
   private function send($method, $uri, $version= '1.0', $headers= [], $body= '') {
-    self::$connection->write($method.' '.$uri.' HTTP/'.$version."\r\n");
-    foreach (['Connection' => 'close'] + $headers as $name => $value) {
-      self::$connection->write($name.': '.$value."\r\n");
+    $this->server->connection->connect();
+    try {
+
+      // Send request. Ensure `Connection: close` is always sent along in order to
+      // be able to read until EOF instead of having to parse the response payload.
+      $this->server->connection->write($method.' '.$uri.' HTTP/'.$version."\r\n");
+      foreach (['Connection' => 'close'] + $headers as $name => $value) {
+        $this->server->connection->write($name.': '.$value."\r\n");
+      }
+      $this->server->connection->write("\r\n".$body);
+
+      // Read response
+      $response= ['status' => $this->server->connection->readLine(), 'headers' => [], 'body' => ''];
+      while ('' !== ($line= $this->server->connection->readLine())) {
+        sscanf($line, "%[^:]: %[^\r]", $name, $value);
+        $response['headers'][$name]= $value;
+      }
+      while (!$this->server->connection->eof()) {
+        $response['body'].= $this->server->connection->read();
+      }
+      return $response;
+    } finally {
+      $this->server->connection->close();
     }
-    self::$connection->write("\r\n".$body);
-  }
-
-  /**
-   * Receives a response
-   *
-   * @return [:var]
-   */
-  private function receive() {
-    $response= ['status' => self::$connection->readLine(), 'headers' => [], 'body' => ''];
-    while ('' !== ($line= self::$connection->readLine())) {
-      sscanf($line, "%[^:]: %[^\r]", $name, $value);
-      $response['headers'][$name]= $value;
-    }
-    while (!self::$connection->eof()) {
-      $response['body'].= self::$connection->read();
-    }
-    return $response;
-  }
-
-  #[Test, Values(['1.0', '1.1'])]
-  public function returns_http_version($version) {
-    $this->send('GET', '/status/200', $version, ['Connection' => 'close']);
-    Assert::equals("HTTP/$version 200 OK", $this->receive()['status']);
-  }
-
-  #[Test]
-  public function date_header_always_present() {
-    $this->send('GET', '/status/200');
-    Assert::true(isset($this->receive()['headers']['Date']));
-  }
-
-  #[Test]
-  public function server_header_always_present() {
-    $this->send('GET', '/status/200', '1.1', ['Connection' => 'close']);
-    Assert::equals('XP', $this->receive()['headers']['Server']);
-  }
-
-  #[Test, Values([[200, '200 OK'], [404, '404 Not Found'], [420, '420 Enhance your calm']])]
-  public function echo_status($code, $expected) {
-    $this->send('GET', '/status/'.$code);
-    Assert::equals("HTTP/1.0 $expected", $this->receive()['status']);
-  }
-
-  #[Test, Values([['', '420 Enhance your calm'], ['message=Custom+message', '420 Custom message']])]
-  public function custom_status($query, $expected) {
-    $this->send('GET', '/status/420?'.$query);
-    Assert::equals("HTTP/1.0 $expected", $this->receive()['status']);
-  }
-
-  #[Test, Values([[404, '404 Not Found'], [500, '500 Internal Server Error']])]
-  public function echo_error($code, $expected) {
-    $this->send('GET', '/raise/error/'.$code);
-    Assert::equals("HTTP/1.0 $expected", $this->receive()['status']);
-  }
-
-  #[Test]
-  public function dispatching_request() {
-    $this->send('GET', '/dispatch');
-    Assert::equals("HTTP/1.0 420 Dispatched", $this->receive()['status']);
-  }
-
-  #[Test, Values(['lang.IllegalAccessException', 'Exception'])]
-  public function raising_exception_yield_500($class) {
-    $this->send('GET', '/raise/exception/'.$class);
-    Assert::equals("HTTP/1.0 500 Internal Server Error", $this->receive()['status']);
-  }
-
-  #[Test]
-  public function unrouted_uris_yield_404() {
-    $this->send('GET', '/not-routed');
-    Assert::equals("HTTP/1.0 404 Not Found", $this->receive()['status']);
   }
 
   #[Test]
   public function malformed_protocol() {
-    self::$connection->write("EHLO example.org\r\n");
-    Assert::equals("HTTP/1.1 400 Bad Request", self::$connection->readLine());
+    $this->server->connection->connect();
+    try {
+      $this->server->connection->write("EHLO example.org\r\n");
+      $status= $this->server->connection->readLine();
+    } finally {
+      $this->server->connection->close();
+    }
+    Assert::equals("HTTP/1.1 400 Bad Request", $status);
+  }
+
+  #[Test, Values(['1.0', '1.1'])]
+  public function returns_http_version($version) {
+    $r= $this->send('GET', '/status/200', $version);
+    Assert::equals("HTTP/$version 200 OK", $r['status']);
+  }
+
+  #[Test]
+  public function date_header_always_present() {
+    $r= $this->send('GET', '/status/200');
+    Assert::true(isset($r['headers']['Date']));
+  }
+
+  #[Test]
+  public function server_header_always_present() {
+    $r= $this->send('GET', '/status/200', '1.1', ['Connection' => 'close']);
+    Assert::equals('XP', $r['headers']['Server']);
+  }
+
+  #[Test, Values([[200, '200 OK'], [404, '404 Not Found'], [420, '420 Enhance your calm']])]
+  public function echo_status($code, $expected) {
+    $r= $this->send('GET', '/status/'.$code);
+    Assert::equals("HTTP/1.0 $expected", $r['status']);
+  }
+
+  #[Test, Values([['', '420 Enhance your calm'], ['message=Custom+message', '420 Custom message']])]
+  public function custom_status($query, $expected) {
+    $r= $this->send('GET', '/status/420?'.$query);
+    Assert::equals("HTTP/1.0 $expected", $r['status']);
+  }
+
+  #[Test, Values([[404, '404 Not Found'], [500, '500 Internal Server Error']])]
+  public function echo_error($code, $expected) {
+    $r= $this->send('GET', '/raise/error/'.$code);
+    Assert::equals("HTTP/1.0 $expected", $r['status']);
+  }
+
+  #[Test]
+  public function dispatching_request() {
+    $r= $this->send('GET', '/dispatch');
+    Assert::equals("HTTP/1.0 420 Dispatched", $r['status']);
+  }
+
+  #[Test, Values(['lang.IllegalAccessException', 'Exception'])]
+  public function raising_exception_yield_500($class) {
+    $r= $this->send('GET', '/raise/exception/'.$class);
+    Assert::equals("HTTP/1.0 500 Internal Server Error", $r['status']);
+  }
+
+  #[Test]
+  public function unrouted_uris_yield_404() {
+    $r= $this->send('GET', '/not-routed');
+    Assert::equals("HTTP/1.0 404 Not Found", $r['status']);
   }
 
   #[Test]
   public function content_comes_with_length() {
-    $this->send('GET', '/content?data=Test');
-    $response= $this->receive();
-
-    Assert::equals(['4', 'Test'], [$response['headers']['Content-Length'], $response['body']]);
+    $r= $this->send('GET', '/content?data=Test');
+    Assert::equals(['4', 'Test'], [$r['headers']['Content-Length'], $r['body']]);
   }
 
   #[Test]
   public function post_body_read() {
     $headers= ['Content-Type' => self::FORM_URLENCODED, 'Content-Length' => 9];
-    $this->send('POST', '/content', '1.0', $headers, 'data=Test');
-    $response= $this->receive();
-
-    Assert::equals(['4', 'Test'], [$response['headers']['Content-Length'], $response['body']]);
+    $r= $this->send('POST', '/content', '1.0', $headers, 'data=Test');
+    Assert::equals(['4', 'Test'], [$r['headers']['Content-Length'], $r['body']]);
   }
 
   #[Test]
   public function chunked_body_read() {
     $headers= ['Content-Type' => self::FORM_URLENCODED, 'Transfer-Encoding' => 'chunked'];
-    $this->send('POST', '/content', '1.1', $headers, "9\r\ndata=Test\r\n0\r\n\r\n");
-    $response= $this->receive();
-
-    Assert::equals(['4', 'Test'], [$response['headers']['Content-Length'], $response['body']]);
+    $r= $this->send('POST', '/content', '1.1', $headers, "9\r\ndata=Test\r\n0\r\n\r\n");
+    Assert::equals(['4', 'Test'], [$r['headers']['Content-Length'], $r['body']]);
   }
 
   #[Test]
   public function stream_comes_with_length_in_http10() {
-    $this->send('GET', '/stream?data=Test', '1.0');
-    $response= $this->receive();
-
-    Assert::equals(['4', 'Test'], [$response['headers']['Content-Length'], $response['body']]);
+    $r= $this->send('GET', '/stream?data=Test', '1.0');
+    Assert::equals(['4', 'Test'], [$r['headers']['Content-Length'], $r['body']]);
   }
 
   #[Test]
   public function stream_comes_with_chunked_te_in_http11() {
-    $this->send('GET', '/stream?data=Test', '1.1');
-    $response= $this->receive();
-
-    Assert::equals('chunked', $response['headers']['Transfer-Encoding']);
-    Assert::equals("4\r\nTest\r\n0\r\n\r\n", $response['body']);
+    $r= $this->send('GET', '/stream?data=Test', '1.1');
+    Assert::equals('chunked', $r['headers']['Transfer-Encoding']);
+    Assert::equals("4\r\nTest\r\n0\r\n\r\n", $r['body']);
   }
 
   #[Test, Values([1024, 4096, 8192])]
   public function with_large_cookie($length) {
     $header= 'cookie='.str_repeat('*', $length);
-    $this->send('GET', '/cookie', '1.0', ['Cookie' => $header]);
-    $response= $this->receive();
-
-    Assert::equals((string)strlen($header), $response['body']);
+    $r= $this->send('GET', '/cookie', '1.0', ['Cookie' => $header]);
+    Assert::equals((string)strlen($header), $r['body']);
   }
 }

--- a/src/it/php/web/unittest/StartServer.class.php
+++ b/src/it/php/web/unittest/StartServer.class.php
@@ -1,77 +1,46 @@
 <?php namespace web\unittest;
 
-use lang\{Runtime, XPClass};
+use lang\{Runtime, IllegalStateException};
 use peer\Socket;
-use unittest\{PrerequisitesNotMetError, Test, TestAction, TestClassAction};
+use test\Provider;
+use test\execution\Context;
 
-class StartServer implements TestAction, TestClassAction {
-  private $server, $connected, $process, $client;
+class StartServer implements Provider {
+  private $server;
+  private $process= null;
+  public $connection= null;
 
   /**
    * Constructor
    *
    * @param string $server Server process main class
-   * @param string $connected Name of connection callback
    */
-  public function __construct($server, $connected) {
-    $this->server= $server;
-    $this->connected= $connected;
+  public function __construct($server) {
+    $this->server= strtr($server, '\\', '.');
   }
 
-  /**
-   * Starts server
-   *
-   * @param  lang.XPClass $c
-   * @return void
-   * @throws unittest.PrerequisitesNotMetError
-   */
-  public function beforeTestClass(XPClass $c) {
+  public function values(Context $context): iterable {
     $this->process= Runtime::getInstance()->newInstance(null, 'class', $this->server, []);
     $this->process->in->close();
 
     // Check if startup succeeded
     $status= $this->process->out->readLine();
     if (2 !== sscanf($status, '+ Service %[0-9.]:%d', $host, $port)) {
-      $this->afterTestClass($c);
-      throw new PrerequisitesNotMetError('Cannot start server: '.$status, null);
+      $this->shutdown();
+      throw new IllegalStateException('Cannot start server: '.$status, null);
     }
 
-    $this->client= new Socket($host, $port);
-    $c->getMethod($this->connected)->invoke(null, [$this->client]);
+    $this->connection= new Socket($host, $port);
+    yield $this;
   }
 
-  /**
-   * This method gets invoked before a test method is invoked, and before
-   * the setUp() method is called.
-   *
-   * @param  unittest.Test $t
-   * @return void
-   * @throws unittest.PrerequisitesNotMetError
-   */
-  public function beforeTest(Test $t) {
-    $this->client->connect();
-  }
+  /** @return void */
+  public function shutdown() {
+    if (null === $this->process) return;
 
-  /**
-   * This method gets invoked after the test method is invoked and regard-
-   * less of its outcome, after the tearDown() call has run.
-   *
-   * @param  unittest.Test $t
-   * @return void
-   */
-  public function afterTest(Test $t) {
-    $this->client->close();
-  }
-
-  /**
-   * Shuts down server
-   *
-   * @param  lang.XPClass $c
-   * @return void
-   */
-  public function afterTestClass(XPClass $c) {
     $this->process->err->close();
     $this->process->out->close();
     $this->process->terminate();
+    $this->process= null;
   }
 }

--- a/src/it/php/web/unittest/StartServer.class.php
+++ b/src/it/php/web/unittest/StartServer.class.php
@@ -19,7 +19,7 @@ class StartServer implements Provider {
     $this->server= strtr($server, '\\', '.');
   }
 
-  public function values(Context $context): iterable {
+  public function values(Context $context) {
     $this->process= Runtime::getInstance()->newInstance(null, 'class', $this->server, []);
     $this->process->in->close();
 

--- a/src/it/php/web/unittest/TestingApplication.class.php
+++ b/src/it/php/web/unittest/TestingApplication.class.php
@@ -1,7 +1,7 @@
 <?php namespace web\unittest;
 
 use lang\XPClass;
-use unittest\Assert;
+use test\Assert;
 use web\{Application, Error};
 
 class TestingApplication extends Application {

--- a/src/it/php/web/unittest/TestingServer.class.php
+++ b/src/it/php/web/unittest/TestingServer.class.php
@@ -3,7 +3,7 @@
 use lang\Throwable;
 use peer\ServerSocket;
 use peer\server\Server;
-use unittest\Assert;
+use test\Assert;
 use util\cmd\Console;
 use web\{Environment, Logging};
 use xp\web\srv\HttpProtocol;

--- a/src/test/php/web/unittest/ApplicationTest.class.php
+++ b/src/test/php/web/unittest/ApplicationTest.class.php
@@ -1,16 +1,15 @@
 <?php namespace web\unittest;
 
 use lang\IllegalStateException;
-use unittest\{Expect, Test};
+use test\{Assert, Expect, Test, Values};
 use util\Objects;
 use web\io\{TestInput, TestOutput};
 use web\{Application, Environment, Error, Filter, Filters, Handler, Request, Response, Routing};
 
-class ApplicationTest extends \unittest\TestCase {
+class ApplicationTest {
   private $environment;
 
-  /** @return void */
-  public function setUp() {
+  public function __construct() {
     $this->environment= new Environment('dev', '.', 'static', []);
   }
 
@@ -50,7 +49,7 @@ class ApplicationTest extends \unittest\TestCase {
    */
   private function assertHandled(&$handled, $routes) {
     $result= $this->handle($routes);
-    $this->assertEquals([$result], $handled);
+    Assert::equals([$result], $handled);
   }
 
   #[Test]
@@ -65,7 +64,7 @@ class ApplicationTest extends \unittest\TestCase {
     $app= new class($this->environment) extends Application {
       public function routes() { /* Implementation irrelevant for this test */ }
     };
-    $this->assertEquals($this->environment, $app->environment());
+    Assert::equals($this->environment, $app->environment());
   }
 
   #[Test]
@@ -74,7 +73,7 @@ class ApplicationTest extends \unittest\TestCase {
     $app= newinstance(Application::class, [$this->environment], [
       'routes' => function() use($routing) { return $routing; }
     ]);
-    $this->assertEquals($routing, $app->routing());
+    Assert::equals($routing, $app->routing());
   }
 
   #[Test]
@@ -90,7 +89,7 @@ class ApplicationTest extends \unittest\TestCase {
       }
     ]);
     $app->routing();
-    $this->assertEquals($routing, $app->routing());
+    Assert::equals($routing, $app->routing());
   }
 
   #[Test]
@@ -158,7 +157,7 @@ class ApplicationTest extends \unittest\TestCase {
         },
       ];
     });
-    $this->assertEquals([], $passed);
+    Assert::equals([], $passed);
   }
 
   #[Test]
@@ -174,10 +173,10 @@ class ApplicationTest extends \unittest\TestCase {
         },
       ];
     });
-    $this->assertEquals(['url' => 'http://example.com/'], $passed);
+    Assert::equals(['url' => 'http://example.com/'], $passed);
   }
 
-  #[Test, Expect(['class' => Error::class, 'withMessage' => '/Internal redirect loop/'])]
+  #[Test, Expect(class: Error::class, message: '/Internal redirect loop/')]
   public function dispatch_request_to_self_causes_error() {
     $this->assertHandled($handled, function() use(&$handled) {
       return [
@@ -188,7 +187,7 @@ class ApplicationTest extends \unittest\TestCase {
     });
   }
 
-  #[Test, Expect(['class' => Error::class, 'withMessage' => '/Internal redirect loop/'])]
+  #[Test, Expect(class: Error::class, message: '/Internal redirect loop/')]
   public function dispatch_request_ping_pong_causes_error() {
     $this->assertHandled($handled, function() use(&$handled) {
       return [
@@ -221,7 +220,7 @@ class ApplicationTest extends \unittest\TestCase {
 
   #[Test]
   public function string_representation() {
-    $this->assertEquals(
+    Assert::equals(
       'web.unittest.HelloWorld(static)',
       (new HelloWorld($this->environment))->toString()
     );
@@ -229,22 +228,22 @@ class ApplicationTest extends \unittest\TestCase {
 
   #[Test]
   public function hash_code() {
-    $this->assertNotEquals('', (new HelloWorld($this->environment))->hashCode());
+    Assert::notEquals('', (new HelloWorld($this->environment))->hashCode());
   }
 
   #[Test]
   public function equals_itself() {
     $app= new HelloWorld($this->environment);
-    $this->assertEquals(0, $app->compareTo($app));
+    Assert::equals(0, $app->compareTo($app));
   }
 
   #[Test]
   public function does_not_equal_clone() {
     $app= new HelloWorld($this->environment);
-    $this->assertEquals(1, $app->compareTo(clone $app));
+    Assert::equals(1, $app->compareTo(clone $app));
   }
 
-  #[Test, Values('filters')]
+  #[Test, Values(from: 'filters')]
   public function install_filter($install) {
     list($request, $response)= $this->handle(function() use($install) {
       $this->install($install);
@@ -253,7 +252,7 @@ class ApplicationTest extends \unittest\TestCase {
         $res->send($req->value('filtered'), 'text/plain');
       };
     });
-    $this->assertEquals('true', $response->output()->body());
+    Assert::equals('true', $response->output()->body());
   }
 
   #[Test]
@@ -272,7 +271,7 @@ class ApplicationTest extends \unittest\TestCase {
         $res->send(Objects::stringOf($req->values()), 'text/plain');
       };
     });
-    $this->assertEquals(
+    Assert::equals(
       Objects::stringOf(['filtered' => 'true', 'enhanced' => 'twice']),
       $response->output()->body()
     );

--- a/src/test/php/web/unittest/AsyncTest.class.php
+++ b/src/test/php/web/unittest/AsyncTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace web\unittest;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 use web\io\{TestInput, TestOutput};
 use web\{Request, Response};
 

--- a/src/test/php/web/unittest/Chunking.class.php
+++ b/src/test/php/web/unittest/Chunking.class.php
@@ -1,5 +1,4 @@
 <?php namespace web\unittest;
-
 /**
  * Chunked transfer encoding
  *

--- a/src/test/php/web/unittest/CookieTest.class.php
+++ b/src/test/php/web/unittest/CookieTest.class.php
@@ -1,11 +1,11 @@
 <?php namespace web\unittest;
 
 use lang\IllegalArgumentException;
-use unittest\{Expect, Test, TestCase, Values};
+use test\{Assert, Expect, Test, Values};
 use util\{Date, TimeSpan};
 use web\{Cookie, Headers};
 
-class CookieTest extends TestCase {
+class CookieTest {
 
   #[Test]
   public function can_create() {
@@ -14,7 +14,7 @@ class CookieTest extends TestCase {
 
   #[Test]
   public function name() {
-    $this->assertEquals('name', (new Cookie('name', 'value'))->name());
+    Assert::equals('name', (new Cookie('name', 'value'))->name());
   }
 
   #[Test, Expect(IllegalArgumentException::class), Values(["=", ",", ";", " ", "\t", "\r", "\n", "\013", "\014"])]
@@ -24,12 +24,12 @@ class CookieTest extends TestCase {
 
   #[Test]
   public function value() {
-    $this->assertEquals('value', (new Cookie('name', 'value'))->value());
+    Assert::equals('value', (new Cookie('name', 'value'))->value());
   }
 
   #[Test]
   public function attributes() {
-    $this->assertEquals(
+    Assert::equals(
       [
         'expires'  => null,
         'maxAge'   => null,
@@ -45,7 +45,7 @@ class CookieTest extends TestCase {
 
   #[Test]
   public function http_only_and_same_site_per_default() {
-    $this->assertEquals(
+    Assert::equals(
       'name=value; SameSite=Lax; HttpOnly',
       (new Cookie('name', 'value'))->header()
     );
@@ -53,7 +53,7 @@ class CookieTest extends TestCase {
 
   #[Test]
   public function removing_http_only() {
-    $this->assertEquals(
+    Assert::equals(
       'name=value; SameSite=Lax',
       (new Cookie('name', 'value'))->httpOnly(false)->header()
     );
@@ -61,7 +61,7 @@ class CookieTest extends TestCase {
 
   #[Test]
   public function removing_same_site() {
-    $this->assertEquals(
+    Assert::equals(
       'name=value; HttpOnly',
       (new Cookie('name', 'value'))->sameSite(null)->header()
     );
@@ -69,7 +69,7 @@ class CookieTest extends TestCase {
 
   #[Test]
   public function adding_path() {
-    $this->assertEquals(
+    Assert::equals(
       'name=value; Path=/test; SameSite=Lax; HttpOnly',
       (new Cookie('name', 'value'))->path('/test')->header()
     );
@@ -77,7 +77,7 @@ class CookieTest extends TestCase {
 
   #[Test]
   public function adding_domain() {
-    $this->assertEquals(
+    Assert::equals(
       'name=value; Domain=.example.com; SameSite=Lax; HttpOnly',
       (new Cookie('name', 'value'))->domain('.example.com')->header()
     );
@@ -85,7 +85,7 @@ class CookieTest extends TestCase {
 
   #[Test]
   public function characters_in_value_get_encoded() {
-    $this->assertEquals(
+    Assert::equals(
       'name=%22val%C3%BCe%22%20with%20spaces; SameSite=Lax; HttpOnly',
       (new Cookie('name', '"valüe" with spaces'))->header()
     );
@@ -93,7 +93,7 @@ class CookieTest extends TestCase {
 
   #[Test]
   public function control_character_in_value_gets_encoded() {
-    $this->assertEquals(
+    Assert::equals(
       'name=a%00; SameSite=Lax; HttpOnly',
       (new Cookie('name', "a\0"))->header()
     );
@@ -101,7 +101,7 @@ class CookieTest extends TestCase {
 
   #[Test]
   public function semicolon_in_value_gets_encoded() {
-    $this->assertEquals(
+    Assert::equals(
       'name=a%3B; SameSite=Lax; HttpOnly',
       (new Cookie('name', 'a;'))->header()
     );
@@ -109,7 +109,7 @@ class CookieTest extends TestCase {
 
   #[Test]
   public function setting_max_age_to_zero() {
-    $this->assertEquals(
+    Assert::equals(
       'name=value; Max-Age=0; SameSite=Lax; HttpOnly',
       (new Cookie('name', 'value'))->maxAge(0)->header()
     );
@@ -117,7 +117,7 @@ class CookieTest extends TestCase {
 
   #[Test, Values(eval: '[3600, new TimeSpan(3600)]')]
   public function setting_max_age($value) {
-    $this->assertEquals(
+    Assert::equals(
       'name=value; Max-Age=3600; SameSite=Lax; HttpOnly',
       (new Cookie('name', 'value'))->maxAge($value)->header()
     );
@@ -125,7 +125,7 @@ class CookieTest extends TestCase {
 
   #[Test, Values(eval: '["Sat, 19 Nov 2016 16:29:22 GMT", new Date("Sat, 19 Nov 2016 16:29:22 GMT"), 1479572962]')]
   public function setting_expiry($value) {
-    $this->assertEquals(
+    Assert::equals(
       'name=value; Expires=Sat, 19 Nov 2016 16:29:22 GMT; SameSite=Lax; HttpOnly',
       (new Cookie('name', 'value'))->expires($value)->header()
     );
@@ -133,7 +133,7 @@ class CookieTest extends TestCase {
 
   #[Test]
   public function use_null_to_remove() {
-    $this->assertEquals(
+    Assert::equals(
       'name=; Expires='.Headers::date(time() - 86400 * 365).'; Max-Age=0; SameSite=Lax; HttpOnly',
       (new Cookie('name', null))->header()
     );
@@ -141,7 +141,7 @@ class CookieTest extends TestCase {
 
   #[Test]
   public function setting_secure() {
-    $this->assertEquals(
+    Assert::equals(
       'name=value; SameSite=Lax; Secure; HttpOnly',
       (new Cookie('name', 'value'))->secure()->header()
     );
@@ -149,7 +149,7 @@ class CookieTest extends TestCase {
 
   #[Test]
   public function string_representation() {
-    $this->assertEquals(
+    Assert::equals(
       'web.Cookie<name=value; SameSite=Lax; HttpOnly>',
       (new Cookie('name', 'value'))->toString()
     );
@@ -157,16 +157,16 @@ class CookieTest extends TestCase {
 
   #[Test]
   public function hash_code() {
-    $this->assertEquals(705299525, (new Cookie('name', 'value'))->hashCode());
+    Assert::equals(705299525, (new Cookie('name', 'value'))->hashCode());
   }
 
   #[Test]
   public function compare_with_same_name_and_value() {
-    $this->assertEquals(0, (new Cookie('name', 'value'))->compareTo(new Cookie('name', 'value')));
+    Assert::equals(0, (new Cookie('name', 'value'))->compareTo(new Cookie('name', 'value')));
   }
 
   #[Test]
   public function compare_with_different_value() {
-    $this->assertEquals(1, (new Cookie('name', 'value'))->compareTo(new Cookie('name', 'other')));
+    Assert::equals(1, (new Cookie('name', 'value'))->compareTo(new Cookie('name', 'other')));
   }
 }

--- a/src/test/php/web/unittest/EnvironmentTest.class.php
+++ b/src/test/php/web/unittest/EnvironmentTest.class.php
@@ -1,12 +1,12 @@
 <?php namespace web\unittest;
 
-use io\{Path, Files, File};
+use io\{File, Files, Path};
 use lang\{ElementNotFoundException, Environment as System};
-use unittest\{Expect, Test, TestCase, Values};
+use test\{Assert, Expect, Test, Values};
 use util\{Properties, PropertySource, RegisteredPropertySource};
 use web\{Environment, Logging};
 
-class EnvironmentTest extends TestCase {
+class EnvironmentTest {
 
   /** @return iterable */
   private function expansions() {
@@ -25,33 +25,33 @@ class EnvironmentTest extends TestCase {
 
   #[Test]
   public function profile() {
-    $this->assertEquals('dev', (new Environment('dev', '.', 'static', []))->profile());
+    Assert::equals('dev', (new Environment('dev', '.', 'static', []))->profile());
   }
 
   #[Test]
   public function webroot() {
-    $this->assertEquals(new Path('.'), (new Environment('dev', '.', 'static', []))->webroot());
+    Assert::equals(new Path('.'), (new Environment('dev', '.', 'static', []))->webroot());
   }
 
   #[Test]
   public function docroot() {
-    $this->assertEquals(new Path('static'), (new Environment('dev', '.', 'static', []))->docroot());
+    Assert::equals(new Path('static'), (new Environment('dev', '.', 'static', []))->docroot());
   }
 
   #[Test]
   public function logging_goes_to_console_by_defaul() {
-    $this->assertEquals(Logging::of('-'), (new Environment('dev', '.', 'static', []))->logging());
+    Assert::equals(Logging::of('-'), (new Environment('dev', '.', 'static', []))->logging());
   }
 
   #[Test]
   public function variable() {
     putenv('XP_TEST=abc');
-    $this->assertEquals('abc', (new Environment('dev', '.', 'static', []))->variable('XP_TEST'));
+    Assert::equals('abc', (new Environment('dev', '.', 'static', []))->variable('XP_TEST'));
   }
 
   #[Test]
   public function tempDir() {
-    $this->assertTrue(is_dir((new Environment('dev', '.', 'static', []))->tempDir()));
+    Assert::true(is_dir((new Environment('dev', '.', 'static', []))->tempDir()));
   }
 
   #[Test]
@@ -64,7 +64,7 @@ class EnvironmentTest extends TestCase {
     }
 
     try {
-      $this->assertTrue(is_dir((new Environment('dev', '.', 'static', []))->tempDir()));
+      Assert::true(is_dir((new Environment('dev', '.', 'static', []))->tempDir()));
     } finally {
       $_ENV+= $restore;
     }
@@ -73,7 +73,7 @@ class EnvironmentTest extends TestCase {
   #[Test]
   public function path() {
     $environment= new Environment('dev', '.', 'static', []);
-    $this->assertEquals(
+    Assert::equals(
       new Path($environment->webroot(), 'src/main/handlebars'),
       $environment->path('src/main/handlebars')
     );
@@ -82,7 +82,7 @@ class EnvironmentTest extends TestCase {
   #[Test]
   public function non_existant_variable() {
     putenv('XP_TEST');
-    $this->assertNull((new Environment('dev', '.', 'static', []))->variable('XP_TEST'));
+    Assert::null((new Environment('dev', '.', 'static', []))->variable('XP_TEST'));
   }
 
   #[Test, Expect(ElementNotFoundException::class)]
@@ -92,14 +92,14 @@ class EnvironmentTest extends TestCase {
 
   #[Test]
   public function optional_non_existant_properties() {
-    $this->assertNull((new Environment('dev', '.', 'static', []))->properties('inject', true));
+    Assert::null((new Environment('dev', '.', 'static', []))->properties('inject', true));
   }
 
   #[Test, Values([true, false])]
   public function properties($optional) {
     $prop= new Properties('inject.ini');
     $environment= new Environment('dev', '.', 'static', [new RegisteredPropertySource('inject', $prop)]);
-    $this->assertEquals($prop, $environment->properties('inject', $optional));
+    Assert::equals($prop, $environment->properties('inject', $optional));
   }
 
   #[Test]
@@ -109,7 +109,7 @@ class EnvironmentTest extends TestCase {
 
     try {
       $environment= new Environment('dev', '.', 'static', [$file->getURI()]);
-      $this->assertEquals('value', $environment->properties('inject')->readString('test', 'key'));
+      Assert::equals('value', $environment->properties('inject')->readString('test', 'key'));
     } finally {
       $file->unlink();
     }
@@ -122,20 +122,20 @@ class EnvironmentTest extends TestCase {
 
     try {
       $environment= new Environment('dev', '.', 'static', [$file->getPath()]);
-      $this->assertEquals('value', $environment->properties('inject')->readString('test', 'key'));
+      Assert::equals('value', $environment->properties('inject')->readString('test', 'key'));
     } finally {
       $file->unlink();
     }
   }
 
-  #[Test, Values('expansions')]
+  #[Test, Values(from: 'expansions')]
   public function property_expansions($value, $expanded) {
     $file= new File(System::tempDir(), 'inject.ini');
     Files::write($file, "[test]\nkey=".$value);
 
     try {
       $environment= new Environment('dev', '.', 'static', [$file->getURI()]);
-      $this->assertEquals($expanded($environment), $environment->properties('inject')->readString('test', 'key'));
+      Assert::equals($expanded($environment), $environment->properties('inject')->readString('test', 'key'));
     } finally {
       $file->unlink();
     }
@@ -147,16 +147,16 @@ class EnvironmentTest extends TestCase {
       new RegisteredPropertySource('inject', new Properties('prod/inject.ini')),
       new RegisteredPropertySource('inject', new Properties('default/inject.ini')),
     ]);
-    $this->assertEquals(2, $environment->properties('inject')->length());
+    Assert::equals(2, $environment->properties('inject')->length());
   }
 
   #[Test]
   public function arguments_empty_by_default() {
-    $this->assertEquals([], (new Environment('dev', '.', 'static', []))->arguments());
+    Assert::equals([], (new Environment('dev', '.', 'static', []))->arguments());
   }
 
   #[Test, Values([[[]], [['test', 'value']]])]
   public function arguments($arguments) {
-    $this->assertEquals($arguments, (new Environment('dev', '.', 'static', [], $arguments))->arguments());
+    Assert::equals($arguments, (new Environment('dev', '.', 'static', [], $arguments))->arguments());
   }
 }

--- a/src/test/php/web/unittest/FiltersTest.class.php
+++ b/src/test/php/web/unittest/FiltersTest.class.php
@@ -1,10 +1,10 @@
 <?php namespace web\unittest;
 
-use unittest\{Test, TestCase};
+use test\{Assert, Test, Values};
 use web\io\{TestInput, TestOutput};
 use web\{Filter, Filters, Request, Response};
 
-class FiltersTest extends TestCase {
+class FiltersTest {
 
   /**
    * Handle filters
@@ -42,7 +42,7 @@ class FiltersTest extends TestCase {
     $this->filter(null, function($req, $res) use(&$invoked) {
       $invoked[]= $req->method().' '.$req->uri()->path();
     });
-    $this->assertEquals(['GET /'], $invoked);
+    Assert::equals(['GET /'], $invoked);
   }
 
   #[Test]
@@ -51,7 +51,7 @@ class FiltersTest extends TestCase {
     $this->filter(null, ['/' => function($req, $res) use(&$invoked) {
       $invoked[]= $req->method().' '.$req->uri()->path();
     }]);
-    $this->assertEquals(['GET /'], $invoked);
+    Assert::equals(['GET /'], $invoked);
   }
 
   #[Test]
@@ -67,7 +67,7 @@ class FiltersTest extends TestCase {
     $this->filter($filter, function($req, $res) use(&$invoked) {
       $invoked[]= $req->method().' '.$req->uri()->path();
     });
-    $this->assertEquals(['GET /rewritten'], $invoked);
+    Assert::equals(['GET /rewritten'], $invoked);
   }
 
   #[Test]
@@ -81,10 +81,10 @@ class FiltersTest extends TestCase {
     $this->filter($filter, function($req, $res) use(&$invoked) {
       $invoked[]= $req->method().' '.$req->uri()->path();
     });
-    $this->assertEquals(['GET /rewritten'], $invoked);
+    Assert::equals(['GET /rewritten'], $invoked);
   }
 
-  #[Test, Values('handlers')]
+  #[Test, Values(from: 'handlers')]
   public function filter_yielding_handler_using_yield_from($handler) {
     $filter= function($req, $res, $invocation) {
       $res->header('X-Filtered', true);
@@ -96,10 +96,10 @@ class FiltersTest extends TestCase {
     };
 
     $res= $this->filter($filter, $handler);
-    $this->assertEquals(['X-Filtered' => '1', 'X-Completed' => '1'], $res->headers());
+    Assert::equals(['X-Filtered' => '1', 'X-Completed' => '1'], $res->headers());
   }
 
-  #[Test, Values('handlers')]
+  #[Test, Values(from: 'handlers')]
   public function filter_yielding_handler_using_return($handler) {
     $filter= function($req, $res, $invocation) {
       $res->header('X-Filtered', true);
@@ -111,11 +111,11 @@ class FiltersTest extends TestCase {
     };
 
     $res= $this->filter($filter, $handler);
-    $this->assertEquals(['X-Filtered' => '1', 'X-Completed' => '1'], $res->headers());
+    Assert::equals(['X-Filtered' => '1', 'X-Completed' => '1'], $res->headers());
   }
 
   /** @deprecated Filters should always use `yield from` or `return`! */
-  #[Test, Values('handlers')]
+  #[Test, Values(from: 'handlers')]
   public function filter_without_return($handler) {
     $filter= function($req, $res, $invocation) {
       $res->header('X-Filtered', true);
@@ -127,6 +127,6 @@ class FiltersTest extends TestCase {
     };
 
     $res= $this->filter($filter, $handler);
-    $this->assertEquals(['X-Filtered' => '1', 'X-Completed' => '1'], $res->headers());
+    Assert::equals(['X-Filtered' => '1', 'X-Completed' => '1'], $res->headers());
   }
 }

--- a/src/test/php/web/unittest/HeadersTest.class.php
+++ b/src/test/php/web/unittest/HeadersTest.class.php
@@ -1,26 +1,26 @@
 <?php namespace web\unittest;
 
 use lang\FormatException;
-use unittest\{Expect, Test, TestCase, Values};
+use test\{Assert, Expect, Test, Values};
 use util\Date;
 use web\{Headers, Parameterized};
 
-class HeadersTest extends TestCase {
+class HeadersTest {
   const TIMESTAMP = 1621063890;
 
   #[Test]
   public function date_of_int() {
-    $this->assertEquals('Sat, 15 May 2021 07:31:30 GMT', Headers::date(self::TIMESTAMP));
+    Assert::equals('Sat, 15 May 2021 07:31:30 GMT', Headers::date(self::TIMESTAMP));
   }
 
   #[Test]
   public function date_of_date_instance() {
-    $this->assertEquals('Sat, 15 May 2021 07:31:30 GMT', Headers::date(new Date(self::TIMESTAMP)));
+    Assert::equals('Sat, 15 May 2021 07:31:30 GMT', Headers::date(new Date(self::TIMESTAMP)));
   }
 
   #[Test, Values(['text/plain;charset=utf-8', 'text/plain; charset=utf-8', 'text/plain; charset="utf-8"'])]
   public function content_type($header) {
-    $this->assertEquals(
+    Assert::equals(
       new Parameterized('text/plain', ['charset' => 'utf-8']),
       Headers::parameterized()->parse($header)
     );
@@ -28,7 +28,7 @@ class HeadersTest extends TestCase {
 
   #[Test, Values(['attachment;filename=fname.ext', 'attachment; filename=fname.ext', 'attachment; filename="fname.ext"',])]
   public function content_disposition($header) {
-    $this->assertEquals(
+    Assert::equals(
       new Parameterized('attachment', ['filename' => 'fname.ext']),
       Headers::parameterized()->parse($header)
     );
@@ -36,7 +36,7 @@ class HeadersTest extends TestCase {
 
   #[Test, Values(['5;url=http://www.w3.org/pub/WWW/People.html', '5; url=http://www.w3.org/pub/WWW/People.html',])]
   public function refresh($header) {
-    $this->assertEquals(
+    Assert::equals(
       new Parameterized('5', ['url' => 'http://www.w3.org/pub/WWW/People.html']),
       Headers::parameterized()->parse($header)
     );
@@ -44,7 +44,7 @@ class HeadersTest extends TestCase {
 
   #[Test]
   public function accept() {
-    $this->assertEquals(
+    Assert::equals(
       [
         new Parameterized('text/html', []),
         new Parameterized('application/json', ['q' => '0.9']),
@@ -56,7 +56,7 @@ class HeadersTest extends TestCase {
 
   #[Test]
   public function forwarded() {
-    $this->assertEquals(
+    Assert::equals(
       [
         ['for' => '192.0.2.60', 'proto' => 'http', 'by' => '203.0.113.43'],
         ['for' => '198.51.100.17'],
@@ -67,7 +67,7 @@ class HeadersTest extends TestCase {
 
   #[Test, Values([['name="\"\""', '""'], ['name="\"T\""', '"T"'], ['name="\"Test\""', '"Test"'], ['name="\"Test=Works; really\""', '"Test=Works; really"'], ['name="\"T\" in the beginning"', '"T" in the beginning'], ['name="In the end, a \"T\""', 'In the end, a "T"'], ['name="A \"T\" in the middle"', 'A "T" in the middle'], ['name="A \"T\" and a \"Q\""', 'A "T" and a "Q"'], ['name="A \"T!"', 'A "T!'], ['name="A T\"!"', 'A T"!']])]
   public function quoted_param($input, $expected) {
-    $this->assertEquals(['name' => $expected], Headers::pairs()->parse($input));
+    Assert::equals(['name' => $expected], Headers::pairs()->parse($input));
   }
 
   #[Test, Expect(FormatException::class), Values(['name="', 'name=""; test="', 'name="\"', 'name="\"\"'])]

--- a/src/test/php/web/unittest/HttpProtocolTest.class.php
+++ b/src/test/php/web/unittest/HttpProtocolTest.class.php
@@ -2,18 +2,23 @@
 
 use io\streams\Streams;
 use peer\SocketException;
-use unittest\{Test, TestCase, Values};
+use test\{Assert, Test, Values};
 use web\{Application, Environment, Logging};
-use xp\web\srv\{HttpProtocol, CannotWrite};
+use xp\web\srv\{CannotWrite, HttpProtocol};
 
-class HttpProtocolTest extends TestCase {
+class HttpProtocolTest {
   private $log;
 
-  /** @return void */
-  public function setUp() {
+  public function __construct() {
     $this->log= new Logging(null);
   }
 
+  /**
+   * Returns an application with given handlers
+   *
+   * @param  var $handler
+   * @return web.Application
+   */
   private function application($handler) {
     return newinstance(Application::class, [new Environment('test', '.', '.', [])], [
       'routes' => function() use($handler) {
@@ -161,7 +166,7 @@ class HttpProtocolTest extends TestCase {
       "\r\n4\r\nTest\r\n0\r\n\r\n",
       $this->handle($p, ["GET / HTTP/1.1\r\n\r\n"])
     );
-    $this->assertInstanceOf(CannotWrite::class, $caught);
-    $this->assertEquals('// Test error', $caught->toString());
+    Assert::instance(CannotWrite::class, $caught);
+    Assert::equals('// Test error', $caught->toString());
   }
 }

--- a/src/test/php/web/unittest/InternalServerErrorTest.class.php
+++ b/src/test/php/web/unittest/InternalServerErrorTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace web\unittest;
 
 use lang\IllegalArgumentException;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 use web\InternalServerError;
 
 class InternalServerErrorTest {

--- a/src/test/php/web/unittest/LoggingTest.class.php
+++ b/src/test/php/web/unittest/LoggingTest.class.php
@@ -1,11 +1,11 @@
 <?php namespace web\unittest;
 
-use unittest\{Test, TestCase, Values};
+use test\{Assert, Test, Values};
 use web\io\{TestInput, TestOutput};
-use web\logging\{ToAllOf, ToFunction, ToConsole};
+use web\logging\{ToAllOf, ToConsole, ToFunction};
 use web\{Error, Logging, Request, Response};
 
-class LoggingTest extends TestCase {
+class LoggingTest {
 
   /** @return iterable */
   private function arguments() {
@@ -26,15 +26,15 @@ class LoggingTest extends TestCase {
   #[Test]
   public function target() {
     $sink= new ToFunction(function($req, $res, $error) { });
-    $this->assertEquals($sink->target(), (new Logging($sink))->target());
+    Assert::equals($sink->target(), (new Logging($sink))->target());
   }
 
   #[Test]
   public function no_logging_target() {
-    $this->assertEquals('(no logging)', (new Logging(null))->target());
+    Assert::equals('(no logging)', (new Logging(null))->target());
   }
 
-  #[Test, Values('arguments')]
+  #[Test, Values(from: 'arguments')]
   public function log($expected, $error) {
     $req= new Request(new TestInput('GET', '/'));
     $res= new Response(new TestOutput());
@@ -45,26 +45,26 @@ class LoggingTest extends TestCase {
     }));
     $log->log($req, $res, $error);
 
-    $this->assertEquals([$expected], $logged);
+    Assert::equals([$expected], $logged);
   }
 
   #[Test]
   public function pipe() {
     $a= new ToFunction(function($req, $res, $error) { /* a */ });
     $b= new ToFunction(function($req, $res, $error) { /* b */ });
-    $this->assertEquals($b, (new Logging($a))->pipe($b)->sink());
+    Assert::equals($b, (new Logging($a))->pipe($b)->sink());
   }
 
   #[Test]
   public function pipe_with_string_arg() {
-    $this->assertEquals(new ToConsole(), (new Logging())->pipe('-')->sink());
+    Assert::equals(new ToConsole(), (new Logging())->pipe('-')->sink());
   }
 
   #[Test]
   public function tee() {
     $a= new ToFunction(function($req, $res, $error) { /* a */ });
     $b= new ToFunction(function($req, $res, $error) { /* b */ });
-    $this->assertEquals(new ToAllOf($a, $b), (new Logging($a))->tee($b)->sink());
+    Assert::equals(new ToAllOf($a, $b), (new Logging($a))->tee($b)->sink());
   }
 
   #[Test]
@@ -72,18 +72,18 @@ class LoggingTest extends TestCase {
     $a= new ToFunction(function($req, $res, $error) { /* a */ });
     $b= new ToFunction(function($req, $res, $error) { /* b */ });
     $c= new ToFunction(function($req, $res, $error) { /* c */ });
-    $this->assertEquals(new ToAllOf($a, $b, $c), (new Logging($a))->tee($b)->tee($c)->sink());
+    Assert::equals(new ToAllOf($a, $b, $c), (new Logging($a))->tee($b)->tee($c)->sink());
   }
 
   #[Test]
   public function pipe_on_no_logging() {
     $sink= new ToFunction(function($req, $res, $error) { });
-    $this->assertEquals($sink, (new Logging(null))->pipe($sink)->sink());
+    Assert::equals($sink, (new Logging(null))->pipe($sink)->sink());
   }
 
   #[Test]
   public function tee_on_no_logging() {
     $sink= new ToFunction(function($req, $res, $error) { });
-    $this->assertEquals($sink, (new Logging(null))->tee($sink)->sink());
+    Assert::equals($sink, (new Logging(null))->tee($sink)->sink());
   }
 }

--- a/src/test/php/web/unittest/MultipartRequestTest.class.php
+++ b/src/test/php/web/unittest/MultipartRequestTest.class.php
@@ -2,11 +2,11 @@
 
 use io\streams\Streams;
 use lang\FormatException;
-use unittest\{Test, Expect, TestCase, Values};
+use test\{Assert, Expect, Test, Values};
 use web\Request;
 use web\io\{Multipart, TestInput};
 
-class MultipartRequestTest extends TestCase {
+class MultipartRequestTest {
   use Chunking;
 
   const BOUNDARY = '------------------------899f0c287170dd63';
@@ -73,7 +73,7 @@ class MultipartRequestTest extends TestCase {
     yield ['blank.gif', "GIF89a\1\0\1\0\200\0\0\0\0\0\377\377\377\!\371\4\1\0\0\0\0,\0\0\0\0\1\0\1\0@\2\1D\0;"];
   }
 
-  #[Test, Values('files')]
+  #[Test, Values(from: 'files')]
   public function files_in_file_upload($filename, $bytes) {
     $req= new Request(new TestInput('POST', '/', self::$MULTIPART, $this->multipart([
       $this->file($filename, $bytes),
@@ -84,7 +84,7 @@ class MultipartRequestTest extends TestCase {
     foreach ($req->multipart()->files() as $name => $file) {
       $files[$name]= addcslashes($file->bytes(), "\0..\37\177..\377");
     }
-    $this->assertEquals([$filename => addcslashes($bytes, "\0..\37\177..\377")], $files);
+    Assert::equals([$filename => addcslashes($bytes, "\0..\37\177..\377")], $files);
   }
 
   #[Test]
@@ -98,7 +98,7 @@ class MultipartRequestTest extends TestCase {
     foreach ($req->multipart()->parts() as $name => $part) {
       $params[$name]= $part->value();
     }
-    $this->assertEquals(['tc' => 'Checked', 'submit' => 'Upload'], $params);
+    Assert::equals(['tc' => 'Checked', 'submit' => 'Upload'], $params);
   }
 
   #[Test]
@@ -109,9 +109,9 @@ class MultipartRequestTest extends TestCase {
       $this->param('submit', 'Upload')
     ])));
 
-    $this->assertEquals(['tc' => 'Checked'], $req->params(), 'Before iterating parts');
+    Assert::equals(['tc' => 'Checked'], $req->params(), 'Before iterating parts');
     iterator_count($req->multipart()->parts());
-    $this->assertEquals(['tc' => 'Checked', 'submit' => 'Upload'], $req->params(), 'When complete');
+    Assert::equals(['tc' => 'Checked', 'submit' => 'Upload'], $req->params(), 'When complete');
   }
 
   #[Test, Values([['/', []], ['/?a=b', ['a' => 'b']], ['/?a=b&c=d', ['a' => 'b', 'c' => 'd']],])]
@@ -122,7 +122,7 @@ class MultipartRequestTest extends TestCase {
     ])));
 
     iterator_count($req->multipart()->parts());
-    $this->assertEquals($params + ['tc' => 'Checked', 'submit' => 'Upload'], $req->params());
+    Assert::equals($params + ['tc' => 'Checked', 'submit' => 'Upload'], $req->params());
   }
 
   #[Test]
@@ -134,7 +134,7 @@ class MultipartRequestTest extends TestCase {
     ])));
 
     iterator_count($req->multipart()->parts());
-    $this->assertEquals(['accepted' => ['tc', 'privacy'], 'submit' => 'Upload'], $req->params());
+    Assert::equals(['accepted' => ['tc', 'privacy'], 'submit' => 'Upload'], $req->params());
   }
 
   #[Test]
@@ -146,7 +146,7 @@ class MultipartRequestTest extends TestCase {
     ])));
 
     iterator_count($req->multipart()->parts());
-    $this->assertEquals(['accepted' => ['tc' => 'true', 'privacy' => 'true'], 'submit' => 'Upload'], $req->params());
+    Assert::equals(['accepted' => ['tc' => 'true', 'privacy' => 'true'], 'submit' => 'Upload'], $req->params());
   }
 
   #[Test]
@@ -157,7 +157,7 @@ class MultipartRequestTest extends TestCase {
     ])));
 
     $req->multipart();
-    $this->assertEquals((int)$req->header('Content-Length'), $req->consume());
+    Assert::equals((int)$req->header('Content-Length'), $req->consume());
   }
 
   #[Test]
@@ -168,7 +168,7 @@ class MultipartRequestTest extends TestCase {
     ])));
 
     foreach ($req->multipart()->parts() as $part) { }
-    $this->assertEquals(0, $req->consume());
+    Assert::equals(0, $req->consume());
   }
 
   #[Test, Values([0, 4, 0xff, 0x100, 0xffff])]
@@ -181,7 +181,7 @@ class MultipartRequestTest extends TestCase {
     foreach ($req->multipart()->files() as $name => $file) {
       $files[$name]= strlen($file->bytes());
     }
-    $this->assertEquals(['test.txt' => $length], $files);
+    Assert::equals(['test.txt' => $length], $files);
   }
 
   #[Test]
@@ -191,7 +191,7 @@ class MultipartRequestTest extends TestCase {
     ])));
 
     iterator_count($req->multipart()->parts());
-    $this->assertEquals(['test' => 'illegal&char'], $req->params());
+    Assert::equals(['test' => 'illegal&char'], $req->params());
   }
 
   #[Test, Expect(FormatException::class)]

--- a/src/test/php/web/unittest/MultipartTest.class.php
+++ b/src/test/php/web/unittest/MultipartTest.class.php
@@ -1,11 +1,15 @@
 <?php namespace web\unittest;
 
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 use web\Multipart;
 use web\io\Param;
 
 class MultipartTest {
   private $param;
+
+  public function __construct() {
+    $this->param= new Param('key', ['value']);
+  }
 
   /** @return iterator */
   private function parts() {
@@ -18,24 +22,19 @@ class MultipartTest {
     }];
   }
 
-  #[Before]
-  public function param() {
-    $this->param= new Param('key', ['value']);
-  }
-
-  #[Test, Values('parts')]
+  #[Test, Values(from: 'parts')]
   public function can_create($parts) {
     $params= [];
     new Multipart($parts, $params);
   }
 
-  #[Test, Values('parts')]
+  #[Test, Values(from: 'parts')]
   public function peek($parts) {
     $params= [];
     Assert::equals([$this->param], (new Multipart($parts, $params))->peek());
   }
 
-  #[Test, Values('parts')]
+  #[Test, Values(from: 'parts')]
   public function all_parts($parts) {
     $params= [];
     Assert::equals([$this->param], iterator_to_array((new Multipart($parts, $params))->parts()));

--- a/src/test/php/web/unittest/ParameterizedTest.class.php
+++ b/src/test/php/web/unittest/ParameterizedTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace web\unittest;
 
-use unittest\{Test, TestCase, Values};
+use test\{Assert, Test, Values};
 use web\Parameterized;
 
-class ParameterizedTest extends TestCase {
+class ParameterizedTest {
 
   #[Test]
   public function can_create() {
@@ -12,26 +12,26 @@ class ParameterizedTest extends TestCase {
 
   #[Test]
   public function value() {
-    $this->assertEquals('text/plain', (new Parameterized('text/plain', []))->value());
+    Assert::equals('text/plain', (new Parameterized('text/plain', []))->value());
   }
 
   #[Test, Values([[[]], [['charset' => 'utf-8']], [['charset' => 'utf-8', 'level' => '1']],])]
   public function params($params) {
-    $this->assertEquals($params, (new Parameterized('text/plain', $params))->params());
+    Assert::equals($params, (new Parameterized('text/plain', $params))->params());
   }
 
   #[Test]
   public function param_by_name() {
-    $this->assertEquals('utf-8', (new Parameterized('text/plain', ['charset' => 'utf-8']))->param('charset'));
+    Assert::equals('utf-8', (new Parameterized('text/plain', ['charset' => 'utf-8']))->param('charset'));
   }
 
   #[Test]
   public function non_existant_param() {
-    $this->assertNull((new Parameterized('text/plain', ['charset' => 'utf-8']))->param('name'));
+    Assert::null((new Parameterized('text/plain', ['charset' => 'utf-8']))->param('name'));
   }
 
   #[Test, Values([null, 'utf-8'])]
   public function non_existant_param_with($default) {
-    $this->assertEquals($default, (new Parameterized('text/plain', []))->param('charset', $default));
+    Assert::equals($default, (new Parameterized('text/plain', []))->param('charset', $default));
   }
 }

--- a/src/test/php/web/unittest/RangesTest.class.php
+++ b/src/test/php/web/unittest/RangesTest.class.php
@@ -1,10 +1,11 @@
 <?php namespace web\unittest;
 
 use lang\{FormatException, IllegalArgumentException};
-use unittest\{Expect, Test, Values};
+use test\Assert;
+use test\{Expect, Test, Values};
 use web\io\{Range, Ranges};
 
-class RangesTest extends \unittest\TestCase {
+class RangesTest {
   const UNIT = 'bytes';
   const COMPLETE = 100;
 
@@ -44,44 +45,44 @@ class RangesTest extends \unittest\TestCase {
 
   #[Test, Values(['bytes', 'characters'])]
   public function unit($unit) {
-    $this->assertEquals($unit, (new Ranges($unit, $this->newSets(1), self::COMPLETE))->unit());
+    Assert::equals($unit, (new Ranges($unit, $this->newSets(1), self::COMPLETE))->unit());
   }
 
   #[Test]
   public function complete() {
-    $this->assertEquals(self::COMPLETE, (new Ranges(self::UNIT, $this->newSets(1), self::COMPLETE))->complete());
+    Assert::equals(self::COMPLETE, (new Ranges(self::UNIT, $this->newSets(1), self::COMPLETE))->complete());
   }
 
   #[Test, Values([1, 2])]
   public function sets($num) {
     $sets= $this->newSets($num);
-    $this->assertEquals($sets, (new Ranges(self::UNIT, $sets, self::COMPLETE))->sets());
+    Assert::equals($sets, (new Ranges(self::UNIT, $sets, self::COMPLETE))->sets());
   }
 
   #[Test]
   public function single_set() {
     $sets= $this->newSets(1);
-    $this->assertEquals($sets[0], (new Ranges(self::UNIT, $sets, self::COMPLETE))->single());
+    Assert::equals($sets[0], (new Ranges(self::UNIT, $sets, self::COMPLETE))->single());
   }
 
   #[Test]
   public function multiple_sets() {
-    $this->assertNull((new Ranges(self::UNIT, $this->newSets(2), self::COMPLETE))->single());
+    Assert::null((new Ranges(self::UNIT, $this->newSets(2), self::COMPLETE))->single());
   }
 
   #[Test]
   public function no_ranges_in_null() {
-    $this->assertNull(Ranges::in(null, self::COMPLETE));
+    Assert::null(Ranges::in(null, self::COMPLETE));
   }
 
-  #[Test, Values('satisfiable')]
+  #[Test, Values(from: 'satisfiable')]
   public function are_satisfiable($sets, $expected) {
-    $this->assertEquals($expected, (new Ranges(self::UNIT, $sets, 100))->satisfiable());
+    Assert::equals($expected, (new Ranges(self::UNIT, $sets, 100))->satisfiable());
   }
 
   #[Test]
   public function single_set_in() {
-    $this->assertEquals(
+    Assert::equals(
       new Ranges('bytes', [new Range(0, self::COMPLETE - 1)], self::COMPLETE),
       Ranges::in('bytes=0-99', self::COMPLETE)
     );
@@ -90,7 +91,7 @@ class RangesTest extends \unittest\TestCase {
   #[Test]
   public function multiple_sets_in() {
     $last= self::COMPLETE - 1;
-    $this->assertEquals(
+    Assert::equals(
       new Ranges('bytes', [new Range(0, 0), new Range($last, $last)], self::COMPLETE),
       Ranges::in('bytes=0-0,-1', self::COMPLETE)
     );
@@ -98,7 +99,7 @@ class RangesTest extends \unittest\TestCase {
 
   #[Test, Values([1, 10])]
   public function last_n($offset) {
-    $this->assertEquals(
+    Assert::equals(
       new Ranges('bytes', [new Range(self::COMPLETE - $offset, self::COMPLETE - 1)], self::COMPLETE),
       Ranges::in('bytes=-'.$offset, self::COMPLETE)
     );
@@ -106,7 +107,7 @@ class RangesTest extends \unittest\TestCase {
 
   #[Test, Values([0, 1])]
   public function starting_at_until_end($offset) {
-    $this->assertEquals(
+    Assert::equals(
       new Ranges('bytes', [new Range($offset, self::COMPLETE - 1)], self::COMPLETE),
       Ranges::in('bytes='.$offset.'-', self::COMPLETE)
     );
@@ -120,6 +121,6 @@ class RangesTest extends \unittest\TestCase {
   #[Test]
   public function format() {
     $range= new Range(0, 99);
-    $this->assertEquals('bytes 0-99/100', (new Ranges('bytes', [$range], 100))->format($range));
+    Assert::equals('bytes 0-99/100', (new Ranges('bytes', [$range], 100))->format($range));
   }
 }

--- a/src/test/php/web/unittest/RequestTest.class.php
+++ b/src/test/php/web/unittest/RequestTest.class.php
@@ -1,12 +1,12 @@
 <?php namespace web\unittest;
 
 use io\streams\Streams;
-use unittest\{Test, TestCase, Values};
+use test\{Assert, Test, Values};
 use util\URI;
 use web\Request;
 use web\io\TestInput;
 
-class RequestTest extends TestCase {
+class RequestTest {
   use Chunking;
 
   /** @return var[][] */
@@ -33,62 +33,62 @@ class RequestTest extends TestCase {
 
   #[Test]
   public function method() {
-    $this->assertEquals('GET', (new Request(new TestInput('GET', '/')))->method());
+    Assert::equals('GET', (new Request(new TestInput('GET', '/')))->method());
   }
 
   #[Test]
   public function uri() {
-    $this->assertEquals(new URI('http://localhost/'), (new Request(new TestInput('GET', '/')))->uri());
+    Assert::equals(new URI('http://localhost/'), (new Request(new TestInput('GET', '/')))->uri());
   }
 
   #[Test, Values(eval: '["http://localhost/r", new URI("http://localhost/r")]')]
   public function rewrite_request($uri) {
-    $this->assertEquals(new URI('http://localhost/r'), (new Request(new TestInput('GET', '/')))->rewrite($uri)->uri());
+    Assert::equals(new URI('http://localhost/r'), (new Request(new TestInput('GET', '/')))->rewrite($uri)->uri());
   }
 
   #[Test, Values(eval: '["/r", new URI("/r")]')]
   public function rewrite_request_relative($uri) {
-    $this->assertEquals(new URI('http://localhost/r'), (new Request(new TestInput('GET', '/')))->rewrite($uri)->uri());
+    Assert::equals(new URI('http://localhost/r'), (new Request(new TestInput('GET', '/')))->rewrite($uri)->uri());
   }
 
   #[Test]
   public function uri_respects_host_header() {
-    $this->assertEquals(
+    Assert::equals(
       'http://example.com/',
       (string)(new Request(new TestInput('GET', '/', ['Host' => 'example.com'])))->uri()
     );
   }
 
-  #[Test, Values('parameters')]
+  #[Test, Values(from: 'parameters')]
   public function get_params($query, $expected) {
-    $this->assertEquals(
+    Assert::equals(
       ['fixture' => $expected],
       (new Request(new TestInput('GET', '/?'.$query, [])))->params()
     );
   }
 
-  #[Test, Values('parameters')]
+  #[Test, Values(from: 'parameters')]
   public function post_params($query, $expected) {
     $headers= ['Content-Type' => 'application/x-www-form-urlencoded', 'Content-Length' => strlen($query)];
-    $this->assertEquals(
+    Assert::equals(
       ['fixture' => $expected],
       (new Request(new TestInput('POST', '/', $headers, $query)))->params()
     );
   }
 
-  #[Test, Values('parameters')]
+  #[Test, Values(from: 'parameters')]
   public function post_params_chunked($query, $expected) {
     $headers= ['Content-Type' => 'application/x-www-form-urlencoded'] + self::$CHUNKED;
-    $this->assertEquals(
+    Assert::equals(
       ['fixture' => $expected],
       (new Request(new TestInput('POST', '/', $headers, $this->chunked($query, 0xff))))->params()
     );
   }
 
-  #[Test, Values('parameters')]
+  #[Test, Values(from: 'parameters')]
   public function post_params_streamed($query, $expected) {
     $headers= ['Content-Type' => 'application/x-www-form-urlencoded', 'Transfer-Encoding' => 'streamed'];
-    $this->assertEquals(
+    Assert::equals(
       ['fixture' => $expected],
       (new Request(new TestInput('POST', '/', $headers, $query)))->params()
     );
@@ -97,7 +97,7 @@ class RequestTest extends TestCase {
   #[Test]
   public function special_charset_parameter_defined_in_spec() {
     $headers= ['Content-Type' => 'application/x-www-form-urlencoded', 'Content-Length' => 35];
-    $this->assertEquals(
+    Assert::equals(
       ['fixture' => 'Ã¼'],
       (new Request(new TestInput('POST', '/', $headers, 'fixture=%C3%BC&_charset_=iso-8859-1')))->params()
     );
@@ -106,7 +106,7 @@ class RequestTest extends TestCase {
   #[Test, Values([['%C3%BC', 'ü'], ['%E2%82%AC', '€'], ['%F0%9F%98%80', '😀']])]
   public function multi_byte_sequence($hex, $expected) {
     $headers= ['Content-Type' => 'application/x-www-form-urlencoded', 'Content-Length' => 8 + strlen($hex)];
-    $this->assertEquals(
+    Assert::equals(
       ['fixture' => $expected],
       (new Request(new TestInput('POST', '/', $headers, 'fixture='.$hex)))->params()
     );
@@ -115,35 +115,35 @@ class RequestTest extends TestCase {
   #[Test]
   public function charset_in_mediatype_common_nonspec() {
     $headers= ['Content-Type' => 'application/x-www-form-urlencoded; charset=iso-8859-1', 'Content-Length' => 14];
-    $this->assertEquals(
+    Assert::equals(
       ['fixture' => 'Ã¼'],
       (new Request(new TestInput('POST', '/', $headers, 'fixture=%C3%BC')))->params()
     );
   }
 
-  #[Test, Values('parameters')]
+  #[Test, Values(from: 'parameters')]
   public function get_param_named($query, $expected) {
-    $this->assertEquals($expected, (new Request(new TestInput('GET', '/?'.$query)))->param('fixture'));
+    Assert::equals($expected, (new Request(new TestInput('GET', '/?'.$query)))->param('fixture'));
   }
 
   #[Test, Values(['', 'a=b'])]
   public function non_existant_get_param($query) {
-    $this->assertEquals(null, (new Request(new TestInput('GET', '/?'.$query)))->param('fixture'));
+    Assert::equals(null, (new Request(new TestInput('GET', '/?'.$query)))->param('fixture'));
   }
 
   #[Test, Values(['', 'a=b'])]
   public function non_existant_get_param_with_default($query) {
-    $this->assertEquals('test', (new Request(new TestInput('GET', '/?'.$query)))->param('fixture', 'test'));
+    Assert::equals('test', (new Request(new TestInput('GET', '/?'.$query)))->param('fixture', 'test'));
   }
 
   #[Test, Values([[[]], [['X-Test' => 'test']], [['Content-Length' => '6100', 'Content-Type' => 'text/html']]])]
   public function headers($input) {
-    $this->assertEquals($input, (new Request(new TestInput('GET', '/', $input)))->headers());
+    Assert::equals($input, (new Request(new TestInput('GET', '/', $input)))->headers());
   }
 
   #[Test, Values([[['Accept' => ['application/vnd.api+json', 'image/png']]], [['Accept' => 'application/vnd.api+json', 'accept' => 'image/png']]])]
   public function multiple_headers($input) {
-    $this->assertEquals(
+    Assert::equals(
       'application/vnd.api+json, image/png',
       (new Request(new TestInput('GET', '/', $input)))->header('Accept')
     );
@@ -152,52 +152,52 @@ class RequestTest extends TestCase {
   #[Test, Values(['x-test', 'X-Test', 'X-TEST'])]
   public function header_lookup_is_case_insensitive($lookup) {
     $input= ['X-Test' => 'test'];
-    $this->assertEquals('test', (new Request(new TestInput('GET', '/', $input)))->header($lookup));
+    Assert::equals('test', (new Request(new TestInput('GET', '/', $input)))->header($lookup));
   }
 
   #[Test]
   public function non_existant_header() {
-    $this->assertEquals(null, (new Request(new TestInput('GET', '/')))->header('X-Test'));
+    Assert::equals(null, (new Request(new TestInput('GET', '/')))->header('X-Test'));
   }
 
   #[Test]
   public function non_existant_header_with_default() {
-    $this->assertEquals('test', (new Request(new TestInput('GET', '/')))->header('X-Test', 'test'));
+    Assert::equals('test', (new Request(new TestInput('GET', '/')))->header('X-Test', 'test'));
   }
 
   #[Test]
   public function non_existant_value() {
-    $this->assertEquals(null, (new Request(new TestInput('GET', '/')))->value('test'));
+    Assert::equals(null, (new Request(new TestInput('GET', '/')))->value('test'));
   }
 
   #[Test]
   public function non_existant_value_with_default() {
-    $this->assertEquals('Test', (new Request(new TestInput('GET', '/')))->value('test', 'Test'));
+    Assert::equals('Test', (new Request(new TestInput('GET', '/')))->value('test', 'Test'));
   }
 
   #[Test]
   public function inject_value() {
-    $this->assertEquals($this, (new Request(new TestInput('GET', '/')))->pass('test', $this)->value('test'));
+    Assert::equals($this, (new Request(new TestInput('GET', '/')))->pass('test', $this)->value('test'));
   }
 
   #[Test]
   public function values() {
-    $this->assertEquals([], (new Request(new TestInput('GET', '/')))->values());
+    Assert::equals([], (new Request(new TestInput('GET', '/')))->values());
   }
 
   #[Test]
   public function inject_values() {
-    $this->assertEquals(['test' => $this], (new Request(new TestInput('GET', '/')))->pass('test', $this)->values());
+    Assert::equals(['test' => $this], (new Request(new TestInput('GET', '/')))->pass('test', $this)->values());
   }
 
   #[Test]
   public function no_cookies() {
-    $this->assertEquals([], (new Request(new TestInput('GET', '/', [])))->cookies());
+    Assert::equals([], (new Request(new TestInput('GET', '/', [])))->cookies());
   }
 
   #[Test]
   public function cookies() {
-    $this->assertEquals(
+    Assert::equals(
       ['user' => 'thekid', 'tz' => 'Europe/Berlin'],
       (new Request(new TestInput('GET', '/', ['Cookie' => 'user=thekid; tz=Europe%2FBerlin'])))->cookies()
     );
@@ -205,17 +205,17 @@ class RequestTest extends TestCase {
 
   #[Test]
   public function non_existant_cookie() {
-    $this->assertEquals(null, (new Request(new TestInput('GET', '/', [])))->cookie('user'));
+    Assert::equals(null, (new Request(new TestInput('GET', '/', [])))->cookie('user'));
   }
 
   #[Test]
   public function non_existant_cookie_with_guest() {
-    $this->assertEquals('guest', (new Request(new TestInput('GET', '/', [])))->cookie('user', 'guest'));
+    Assert::equals('guest', (new Request(new TestInput('GET', '/', [])))->cookie('user', 'guest'));
   }
 
   #[Test]
   public function cookie() {
-    $this->assertEquals(
+    Assert::equals(
       'Europe/Berlin',
       (new Request(new TestInput('GET', '/', ['Cookie' => 'user=thekid; tz=Europe%2FBerlin'])))->cookie('tz')
     );
@@ -223,7 +223,7 @@ class RequestTest extends TestCase {
 
   #[Test]
   public function cookie_value_decoded() {
-    $this->assertEquals(
+    Assert::equals(
       '"valüe" with spaces',
       (new Request(new TestInput('GET', '/', ['Cookie' => 'test=%22val%C3%BCe%22%20with%20spaces'])))->cookie('test')
     );
@@ -232,7 +232,7 @@ class RequestTest extends TestCase {
   #[Test, Values([0, 8192, 10000])]
   public function stream_with_content_length($length) {
     $body= str_repeat('A', $length);
-    $this->assertEquals(
+    Assert::equals(
       $body,
       Streams::readAll((new Request(new TestInput('GET', '/', ['Content-Length' => $length], $body)))->stream())
     );
@@ -242,7 +242,7 @@ class RequestTest extends TestCase {
   public function form_encoded_payload($length) {
     $body= 'a='.str_repeat('A', $length);
     $headers= ['Content-Length' => $length + 2, 'Content-Type' => 'application/x-www-form-urlencoded'];
-    $this->assertEquals(
+    Assert::equals(
       $body,
       Streams::readAll((new Request(new TestInput('GET', '/', $headers, $body)))->stream())
     );
@@ -251,7 +251,7 @@ class RequestTest extends TestCase {
   #[Test, Values([0, 8180, 10000])]
   public function chunked_payload($length) {
     $transfer= sprintf("5\r\nHello\r\n1\r\n \r\n%x\r\n%s\r\n0\r\n\r\n", $length, str_repeat('A', $length));
-    $this->assertEquals(
+    Assert::equals(
       'Hello '.str_repeat('A', $length),
       Streams::readAll((new Request(new TestInput('GET', '/', self::$CHUNKED, $transfer)))->stream())
     );
@@ -260,39 +260,39 @@ class RequestTest extends TestCase {
   #[Test]
   public function consume_without_data() {
     $req= new Request(new TestInput('GET', '/', []));
-    $this->assertEquals(-1, $req->consume());
+    Assert::equals(-1, $req->consume());
   }
 
   #[Test]
   public function consume_length() {
     $req= new Request(new TestInput('GET', '/', ['Content-Length' => 100], str_repeat('A', 100)));
-    $this->assertEquals(100, $req->consume());
+    Assert::equals(100, $req->consume());
   }
 
   #[Test]
   public function consume_length_after_partial_read() {
     $req= new Request(new TestInput('GET', '/', ['Content-Length' => 100], str_repeat('A', 100)));
     $partial= $req->stream()->read(50);
-    $this->assertEquals(100 - strlen($partial), $req->consume());
+    Assert::equals(100 - strlen($partial), $req->consume());
   }
 
   #[Test]
   public function consume_chunked() {
     $req= new Request(new TestInput('GET', '/', self::$CHUNKED, $this->chunked(str_repeat('A', 100))));
-    $this->assertEquals(100, $req->consume());
+    Assert::equals(100, $req->consume());
   }
 
   #[Test]
   public function consume_chunked_after_partial_read() {
     $req= new Request(new TestInput('GET', '/', self::$CHUNKED, $this->chunked(str_repeat('A', 100))));
     $partial= $req->stream()->read(50);
-    $this->assertEquals(100 - strlen($partial), $req->consume());
+    Assert::equals(100 - strlen($partial), $req->consume());
   }
 
   #[Test]
   public function string_representation() {
     $req= new Request(new TestInput('GET', '/', ['Host' => 'localhost', 'Connection' => 'close']));
-    $this->assertEquals(
+    Assert::equals(
       "web.Request(GET util.URI<http://localhost/>)@[\n".
       "  Host => [\"localhost\"]\n".
       "  Connection => [\"close\"]\n".
@@ -304,6 +304,6 @@ class RequestTest extends TestCase {
   #[Test]
   public function hash_code() {
     $req= new Request(new TestInput('GET', '/', ['Host' => 'localhost', 'Connection' => 'close']));
-    $this->assertEquals(spl_object_hash($req), $req->hashCode());
+    Assert::equals(spl_object_hash($req), $req->hashCode());
   }
 }

--- a/src/test/php/web/unittest/ResponseTest.class.php
+++ b/src/test/php/web/unittest/ResponseTest.class.php
@@ -3,12 +3,12 @@
 use io\Channel;
 use io\streams\MemoryInputStream;
 use lang\{IllegalArgumentException, IllegalStateException};
-use unittest\{Test, Expect, Values, TestCase};
+use test\{Assert, Expect, Test, Values};
 use util\URI;
 use web\io\{Buffered, TestOutput};
 use web\{Cookie, Response};
 
-class ResponseTest extends TestCase {
+class ResponseTest {
 
   /**
    * Assertion helper
@@ -18,7 +18,7 @@ class ResponseTest extends TestCase {
    * @throws unittest.AssertionFailedError
    */
   private function assertResponse($expected, $response) {
-    $this->assertEquals($expected, $response->output()->bytes());
+    Assert::equals($expected, $response->output()->bytes());
   }
 
   #[Test]
@@ -29,41 +29,41 @@ class ResponseTest extends TestCase {
   #[Test]
   public function status_initially_200() {
     $res= new Response(new TestOutput());
-    $this->assertEquals(200, $res->status());
+    Assert::equals(200, $res->status());
   }
 
   #[Test]
   public function status() {
     $res= new Response(new TestOutput());
     $res->answer(201);
-    $this->assertEquals(201, $res->status());
+    Assert::equals(201, $res->status());
   }
 
   #[Test]
   public function message() {
     $res= new Response(new TestOutput());
     $res->answer(201, 'Created');
-    $this->assertEquals('Created', $res->message());
+    Assert::equals('Created', $res->message());
   }
 
   #[Test]
   public function custom_message() {
     $res= new Response(new TestOutput());
     $res->answer(201, 'Creation succeeded');
-    $this->assertEquals('Creation succeeded', $res->message());
+    Assert::equals('Creation succeeded', $res->message());
   }
 
   #[Test]
   public function headers_initially_empty() {
     $res= new Response(new TestOutput());
-    $this->assertEquals([], $res->headers());
+    Assert::equals([], $res->headers());
   }
 
   #[Test]
   public function header() {
     $res= new Response(new TestOutput());
     $res->header('Content-Type', 'text/plain');
-    $this->assertEquals(['Content-Type' => 'text/plain'], $res->headers());
+    Assert::equals(['Content-Type' => 'text/plain'], $res->headers());
   }
 
   #[Test]
@@ -71,7 +71,7 @@ class ResponseTest extends TestCase {
     $res= new Response(new TestOutput());
     $res->header('Content-Type', 'text/plain');
     $res->header('Content-Length', '0');
-    $this->assertEquals(
+    Assert::equals(
       ['Content-Type' => 'text/plain', 'Content-Length' => '0'],
       $res->headers()
     );
@@ -82,14 +82,14 @@ class ResponseTest extends TestCase {
     $res= new Response(new TestOutput());
     $res->header('Content-Type', 'text/plain');
     $res->header('Content-Type', null);
-    $this->assertEquals([], $res->headers());
+    Assert::equals([], $res->headers());
   }
 
   #[Test]
   public function multiple_header() {
     $res= new Response(new TestOutput());
     $res->header('Set-Cookie', ['theme=light', 'sessionToken=abc123']);
-    $this->assertEquals(['Set-Cookie' => ['theme=light', 'sessionToken=abc123']], $res->headers());
+    Assert::equals(['Set-Cookie' => ['theme=light', 'sessionToken=abc123']], $res->headers());
   }
 
   #[Test]
@@ -97,21 +97,21 @@ class ResponseTest extends TestCase {
     $res= new Response(new TestOutput());
     $res->header('Set-Cookie', 'theme=light', true);
     $res->header('Set-Cookie', 'sessionToken=abc123', true);
-    $this->assertEquals(['Set-Cookie' => ['theme=light', 'sessionToken=abc123']], $res->headers());
+    Assert::equals(['Set-Cookie' => ['theme=light', 'sessionToken=abc123']], $res->headers());
   }
 
   #[Test]
   public function uri_header() {
     $res= new Response(new TestOutput());
     $res->header('Location', new URI('http://example.com/'));
-    $this->assertEquals(['Location' => 'http://example.com/'], $res->headers());
+    Assert::equals(['Location' => 'http://example.com/'], $res->headers());
   }
 
   #[Test]
   public function cookie() {
     $res= new Response(new TestOutput());
     $res->cookie(new Cookie('theme', 'light'));
-    $this->assertEquals('light', $res->cookies()[0]->value());
+    Assert::equals('light', $res->cookies()[0]->value());
   }
 
   #[Test]
@@ -123,7 +123,7 @@ class ResponseTest extends TestCase {
       $res->cookie($cookie);
     }
 
-    $this->assertEquals($cookies, $res->cookies());
+    Assert::equals($cookies, $res->cookies());
   }
 
   #[Test, Values([[200, 'OK', 'HTTP/1.1 200 OK'], [404, 'Not Found', 'HTTP/1.1 404 Not Found'], [200, null, 'HTTP/1.1 200 OK'], [404, null, 'HTTP/1.1 404 Not Found'], [200, 'Okay', 'HTTP/1.1 200 Okay'], [404, 'Nope', 'HTTP/1.1 404 Nope']])]
@@ -317,9 +317,9 @@ class ResponseTest extends TestCase {
   #[Test]
   public function flushed() {
     $res= new Response(new TestOutput());
-    $this->assertFalse($res->flushed());
+    Assert::false($res->flushed());
     $res->flush();
-    $this->assertTrue($res->flushed());
+    Assert::true($res->flushed());
   }
 
   #[Test, Expect(IllegalStateException::class)]

--- a/src/test/php/web/unittest/RoutingTest.class.php
+++ b/src/test/php/web/unittest/RoutingTest.class.php
@@ -1,15 +1,14 @@
 <?php namespace web\unittest;
 
-use unittest\{Expect, Test, TestCase, Values};
+use test\{Assert, Expect, Test, Values};
 use web\io\{TestInput, TestOutput};
 use web\routing\{CannotRoute, Target};
 use web\{Application, Environment, Filters, Handler, Request, Response, Route, Routing};
 
-class RoutingTest extends TestCase {
+class RoutingTest {
   private $handlers;
 
-  /** @return void */
-  public function setUp() {
+  public function __construct() {
     $this->handlers= [
       'specific' => new class() implements Handler { public $name= 'specific'; public function handle($req, $res) { }},
       'default'  => new class() implements Handler { public $name= 'default'; public function handle($req, $res) { }},
@@ -29,31 +28,31 @@ class RoutingTest extends TestCase {
 
   #[Test]
   public function routes_initially_empty() {
-    $this->assertEquals([], (new Routing())->routes());
+    Assert::equals([], (new Routing())->routes());
   }
 
   #[Test]
   public function routes_for_empty_map() {
-    $this->assertEquals([], Routing::cast([])->routes());
+    Assert::equals([], Routing::cast([])->routes());
   }
 
   #[Test]
   public function routes_returns_previously_added_map() {
     $route= new Route(new Target('GET', '/'), $this->handlers['default']);
-    $this->assertEquals([$route], (new Routing())->with($route)->routes());
+    Assert::equals([$route], (new Routing())->with($route)->routes());
   }
 
   #[Test]
   public function for_self() {
     $routes= new Routing();
-    $this->assertEquals($routes, Routing::cast($routes));
+    Assert::equals($routes, Routing::cast($routes));
   }
 
-  #[Test, Values(map: ['/api' => 'specific', '/api/' => 'specific', '/api/v1' => 'specific', '/apiv1' => 'default', '/' => 'default'])]
+  #[Test, Values([['/api', 'specific'], ['/api/', 'specific'], ['/api/v1', 'specific'], ['/apiv1', 'default'], ['/', 'default']])]
   public function for_map($path, $expected) {
     $fixture= ['/api' => $this->handlers['specific'], '/' => $this->handlers['default']];
 
-    $this->assertEquals(
+    Assert::equals(
       $this->handlers[$expected],
       Routing::cast($fixture)->route(new Request(new TestInput('GET', $path)))
     );
@@ -73,14 +72,14 @@ class RoutingTest extends TestCase {
         return ['/api' => $this->handlers['specific']];
       }
     };
-    $this->assertEquals($this->handlers['specific'], Routing::cast($app)
+    Assert::equals($this->handlers['specific'], Routing::cast($app)
       ->route(new Request(new TestInput('GET', '/api')))
     );
   }
 
   #[Test]
   public function fallbacks() {
-    $this->assertEquals($this->handlers['default'], (new Routing())
+    Assert::equals($this->handlers['default'], (new Routing())
       ->fallbacks($this->handlers['default'])
       ->route(new Request(new TestInput('GET', '/')))
     );
@@ -88,7 +87,7 @@ class RoutingTest extends TestCase {
 
   #[Test, Values([['/test', 'specific'], ['/test/', 'specific'], ['/test.html', 'default'], ['/', 'default']])]
   public function matching_path($url, $expected) {
-    $this->assertEquals($this->handlers[$expected], (new Routing())
+    Assert::equals($this->handlers[$expected], (new Routing())
       ->matching('/test', $this->handlers['specific'])
       ->fallbacks($this->handlers['default'])
       ->route(new Request(new TestInput('GET', $url)))
@@ -97,7 +96,7 @@ class RoutingTest extends TestCase {
 
   #[Test, Values([['CONNECT', 'specific'], ['GET', 'default']])]
   public function matching_method($verb, $expected) {
-    $this->assertEquals($this->handlers[$expected], (new Routing())
+    Assert::equals($this->handlers[$expected], (new Routing())
       ->matching('CONNECT', $this->handlers['specific'])
       ->fallbacks($this->handlers['default'])
       ->route(new Request(new TestInput($verb, '/')))
@@ -106,7 +105,7 @@ class RoutingTest extends TestCase {
 
   #[Test, Values([['GET', 'specific'], ['POST', 'specific'], ['HEAD', 'default']])]
   public function methods($verb, $expected) {
-    $this->assertEquals($this->handlers[$expected], (new Routing())
+    Assert::equals($this->handlers[$expected], (new Routing())
       ->matching('GET|POST', $this->handlers['specific'])
       ->fallbacks($this->handlers['default'])
       ->route(new Request(new TestInput($verb, '/')))
@@ -115,7 +114,7 @@ class RoutingTest extends TestCase {
 
   #[Test, Values([['GET', 'specific'], ['POST', 'default'], ['HEAD', 'default']])]
   public function matching_target($verb, $expected) {
-    $this->assertEquals($this->handlers[$expected], (new Routing())
+    Assert::equals($this->handlers[$expected], (new Routing())
       ->matching('GET /', $this->handlers['specific'])
       ->fallbacks($this->handlers['default'])
       ->route(new Request(new TestInput($verb, '/')))
@@ -124,7 +123,7 @@ class RoutingTest extends TestCase {
 
   #[Test, Values([['/test', 'specific'], ['/test.html', 'specific'], ['/', 'default']])]
   public function matching_paths($url, $expected) {
-    $this->assertEquals($this->handlers[$expected], (new Routing())
+    Assert::equals($this->handlers[$expected], (new Routing())
       ->matching(['/test', '/test.html'], $this->handlers['specific'])
       ->fallbacks($this->handlers['default'])
       ->route(new Request(new TestInput('GET', $url)))
@@ -133,7 +132,7 @@ class RoutingTest extends TestCase {
 
   #[Test, Values([['GET', 'specific'], ['POST', 'default'], ['HEAD', 'specific']])]
   public function mapping($verb, $expected) {
-    $this->assertEquals($this->handlers[$expected], (new Routing())
+    Assert::equals($this->handlers[$expected], (new Routing())
       ->mapping(
         function($request) { return in_array($request->method(), ['GET', 'HEAD']); },
         $this->handlers['specific']
@@ -145,7 +144,7 @@ class RoutingTest extends TestCase {
 
   #[Test, Values([['GET', 'specific'], ['POST', 'default'], ['HEAD', 'specific']])]
   public function with($verb, $expected) {
-    $this->assertEquals($this->handlers[$expected], (new Routing())
+    Assert::equals($this->handlers[$expected], (new Routing())
       ->with(new Route(new Target(['GET', 'HEAD'], '*'), $this->handlers['specific']))
       ->fallbacks($this->handlers['default'])
       ->route(new Request(new TestInput($verb, '/')))
@@ -154,7 +153,7 @@ class RoutingTest extends TestCase {
 
   #[Test, Values(['/api', '//api', '///api', '/test/../api', '/./api', '/../api', '/./../api',])]
   public function request_canonicalized_before_matching($requested) {
-    $this->assertEquals($this->handlers['specific'], Routing::cast(['/api' => $this->handlers['specific']])
+    Assert::equals($this->handlers['specific'], Routing::cast(['/api' => $this->handlers['specific']])
       ->route(new Request(new TestInput('GET', $requested)))
     );
   }

--- a/src/test/php/web/unittest/SourceTest.class.php
+++ b/src/test/php/web/unittest/SourceTest.class.php
@@ -2,40 +2,39 @@
 
 use io\Path;
 use lang\XPClass;
-use unittest\{Test, TestCase};
+use test\{Assert, Before, Test};
 use web\Environment;
 use xp\web\{ServeDocumentRootStatically, Source};
 
-class SourceTest extends TestCase {
+class SourceTest {
   private $environment;
 
-  /** @return void */
-  public function setUp() {
+  public function __construct() {
     $this->environment= new Environment('dev', '.', 'static', []);
   }
 
   #[Test]
   public function serve_document_root() {
     $src= new Source('-', $this->environment);
-    $this->assertInstanceOf(ServeDocumentRootStatically::class, $src->application());
+    Assert::instance(ServeDocumentRootStatically::class, $src->application());
   }
 
   #[Test]
   public function application_class() {
     $src= new Source('web.unittest.HelloWorld', $this->environment);
-    $this->assertInstanceOf(HelloWorld::class, $src->application());
+    Assert::instance(HelloWorld::class, $src->application());
   }
 
   #[Test]
   public function application_file() {
     $base= XPClass::forName('web.unittest.HelloWorld')->getClassLoader()->path;
     $src= new Source(new Path($base, 'web/unittest/HelloWorld.class.php'), $this->environment);
-    $this->assertInstanceOf(HelloWorld::class, $src->application());
+    Assert::instance(HelloWorld::class, $src->application());
   }
 
   #[Test]
   public function application_class_and_filter() {
     $src= new Source('web.unittest.HelloWorld+xp.web.dev.Console', $this->environment);
-    $this->assertInstanceOf(HelloWorld::class, $src->application());
+    Assert::instance(HelloWorld::class, $src->application());
   }
 }

--- a/src/test/php/web/unittest/filters/BehindProxyTest.class.php
+++ b/src/test/php/web/unittest/filters/BehindProxyTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace web\unittest\filters;
 
 use lang\IllegalArgumentException;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 use web\filters\{BehindProxy, Invocation};
 use web\io\{TestInput, TestOutput};
 use web\{Request, Response};

--- a/src/test/php/web/unittest/filters/InvocationTest.class.php
+++ b/src/test/php/web/unittest/filters/InvocationTest.class.php
@@ -1,12 +1,13 @@
 <?php namespace web\unittest\filters;
 
 use lang\IllegalStateException;
-use unittest\Test;
+use test\Assert;
+use test\Test;
 use web\filters\Invocation;
 use web\io\{TestInput, TestOutput};
 use web\{Filter, Request, Response};
 
-class InvocationTest extends \unittest\TestCase {
+class InvocationTest {
 
   #[Test]
   public function can_create_with_routing_function() {
@@ -23,7 +24,7 @@ class InvocationTest extends \unittest\TestCase {
     $invoked= false;
     $fixture= new Invocation(function($req, $res) use(&$invoked) { $invoked= true; }, []);
     $fixture->proceed(new Request(new TestInput('GET', '/')), new Response(new TestOutput()));
-    $this->assertTrue($invoked);
+    Assert::true($invoked);
   }
 
   #[Test]
@@ -37,7 +38,7 @@ class InvocationTest extends \unittest\TestCase {
       }
     }]);
     $fixture->proceed(new Request(new TestInput('GET', '/')), new Response(new TestOutput()));
-    $this->assertTrue($invoked);
+    Assert::true($invoked);
   }
 
   #[Test]
@@ -59,7 +60,7 @@ class InvocationTest extends \unittest\TestCase {
     ]);
 
     $fixture->proceed(new Request(new TestInput('GET', '/')), new Response(new TestOutput()));
-    $this->assertEquals(['First', 'Second'], $invoked);
+    Assert::equals(['First', 'Second'], $invoked);
   }
 
   #[Test]
@@ -76,7 +77,7 @@ class InvocationTest extends \unittest\TestCase {
   #[Test]
   public function returns_iterable() {
     $fixture= new Invocation(function($req, $res) { }, []);
-    $this->assertEquals([], $fixture->proceed(new Request(new TestInput('GET', '/')), new Response(new TestOutput())));
+    Assert::equals([], $fixture->proceed(new Request(new TestInput('GET', '/')), new Response(new TestOutput())));
   }
 
   #[Test]
@@ -86,6 +87,6 @@ class InvocationTest extends \unittest\TestCase {
         return $invocation->proceed($req, $res);
       }
     }]);
-    $this->assertEquals([], $fixture->proceed(new Request(new TestInput('GET', '/')), new Response(new TestOutput())));
+    Assert::equals([], $fixture->proceed(new Request(new TestInput('GET', '/')), new Response(new TestOutput())));
   }
 }

--- a/src/test/php/web/unittest/handler/CallTest.class.php
+++ b/src/test/php/web/unittest/handler/CallTest.class.php
@@ -1,12 +1,12 @@
 <?php namespace web\unittest\handler;
 
 use lang\IllegalArgumentException;
-use unittest\{Expect, Test, TestCase, Values};
+use test\{Assert, Expect, Test, Values};
 use web\handler\Call;
 use web\io\{TestInput, TestOutput};
 use web\{Request, Response};
 
-class CallTest extends TestCase {
+class CallTest {
 
   /** @return iterable */
   private function invalid() {
@@ -21,7 +21,7 @@ class CallTest extends TestCase {
     new Call(function($request, $response) { });
   }
 
-  #[Test, Expect(IllegalArgumentException::class), Values('invalid')]
+  #[Test, Expect(IllegalArgumentException::class), Values(from: 'invalid')]
   public function create_with_invalid($invokeable) {
     new Call($invokeable);
   }
@@ -37,6 +37,6 @@ class CallTest extends TestCase {
     $response= new Response(new TestOutput());
     (new Call($invokeable))->handle($request, $response);
 
-    $this->assertEquals([[$request, $response]], $handled);
+    Assert::equals([[$request, $response]], $handled);
   }
 }

--- a/src/test/php/web/unittest/handler/FilesFromTest.class.php
+++ b/src/test/php/web/unittest/handler/FilesFromTest.class.php
@@ -2,12 +2,12 @@
 
 use io\{File, Files, Folder, Path};
 use lang\Environment;
-use unittest\{Test, TestCase, Values};
+use test\{Assert, Test, Values};
 use web\handler\FilesFrom;
 use web\io\{TestInput, TestOutput};
-use web\{Request, Response, Headers};
+use web\{Headers, Request, Response};
 
-class FilesFromTest extends TestCase {
+class FilesFromTest {
   private $cleanup= [];
 
   /**
@@ -49,7 +49,7 @@ class FilesFromTest extends TestCase {
    * @throws unittest.AssertionFailedError
    */
   private function assertResponse($expected, $response) {
-    $this->assertEquals($expected, preg_replace(
+    Assert::equals($expected, preg_replace(
       '/[a-z]{3}, [0-9]{2} [a-z]{3} [0-9]{4} [0-9:]{8} GMT/i',
       '<Date>',
       $response->output()->bytes()
@@ -95,6 +95,7 @@ class FilesFromTest extends TestCase {
   }
 
   /** @return void */
+  #[After]
   public function tearDown() {
     foreach ($this->cleanup as $folder) {
       $folder->exists() && $folder->unlink();
@@ -108,7 +109,7 @@ class FilesFromTest extends TestCase {
 
   #[Test, Values(eval: '[["."], [new Path(".")]]')]
   public function path($arg) {
-    $this->assertEquals(new Path('.'), (new FilesFrom($arg))->path());
+    Assert::equals(new Path('.'), (new FilesFrom($arg))->path());
   }
 
   #[Test]

--- a/src/test/php/web/unittest/io/IncompleteTest.class.php
+++ b/src/test/php/web/unittest/io/IncompleteTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace web\unittest\io;
 
 use io\OperationNotSupportedException;
-use unittest\{Assert, Test};
+use test\{Assert, Expect, Test};
 use web\io\{Incomplete, Part};
 
 class IncompleteTest {

--- a/src/test/php/web/unittest/io/OutputTest.class.php
+++ b/src/test/php/web/unittest/io/OutputTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace web\unittest\io;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 use web\io\Output;
 
 class OutputTest {

--- a/src/test/php/web/unittest/io/PartsTest.class.php
+++ b/src/test/php/web/unittest/io/PartsTest.class.php
@@ -3,10 +3,10 @@
 use io\OperationNotSupportedException;
 use io\streams\{InputStream, MemoryInputStream, Streams};
 use lang\FormatException;
-use unittest\{Expect, Test, TestCase, Values};
+use test\{Assert, Expect, Test, Values};
 use web\io\{Part, Parts};
 
-class PartsTest extends TestCase {
+class PartsTest {
   const BOUNDARY = '------------------------899f0c287170dd63';
 
   /**
@@ -39,7 +39,7 @@ class PartsTest extends TestCase {
         $actual[]= ['incomplete', $name, $part->error()];
       }
     }
-    $this->assertEquals($expected, $actual);
+    Assert::equals($expected, $actual);
   }
 
   #[Test]
@@ -175,7 +175,7 @@ class PartsTest extends TestCase {
     };
 
     $it= (new Parts($input, self::BOUNDARY))->getIterator();
-    $this->assertEquals("Hey\r\nNot the end", $it->current()->bytes());
+    Assert::equals("Hey\r\nNot the end", $it->current()->bytes());
   }
 
   #[Test]
@@ -210,7 +210,7 @@ class PartsTest extends TestCase {
         $bytes= Streams::readAll($part);
       }
     }
-    $this->assertEquals('...', $bytes);
+    Assert::equals('...', $bytes);
   }
 
   #[Test, Expect(OperationNotSupportedException::class)]
@@ -251,7 +251,7 @@ class PartsTest extends TestCase {
       '--%1$s--',
       ''
     );
-    $this->assertEquals(
+    Assert::equals(
       'web.io.Param("submit", value= "Upload")',
       iterator_to_array($parts)['submit']->toString()
     );
@@ -268,7 +268,7 @@ class PartsTest extends TestCase {
       '--%1$s--',
       ''
     );
-    $this->assertEquals(
+    Assert::equals(
       'web.io.Stream("test.txt", type= text/plain)',
       iterator_to_array($parts)['upload']->toString()
     );
@@ -289,17 +289,17 @@ class PartsTest extends TestCase {
     $this->assertParts([], $this->parts('', '--%1$s--', ''));
   }
 
-  #[Test, Expect(['class' => FormatException::class, 'withMessage' => '/Malformed or truncated part/'])]
+  #[Test, Expect(class: FormatException::class, message: '/Malformed or truncated part/')]
   public function missing_headers() {
     iterator_to_array($this->parts('--%1$s', ''));
   }
 
-  #[Test, Expect(['class' => FormatException::class, 'withMessage' => '/Malformed or truncated part/'])]
+  #[Test, Expect(class: FormatException::class, message: '/Malformed or truncated part/')]
   public function empty_headers() {
     iterator_to_array($this->parts('--%1$s', '', 'Upload'));
   }
 
-  #[Test, Expect(['class' => FormatException::class, 'withMessage' => '/Malformed or truncated part/'])]
+  #[Test, Expect(class: FormatException::class, message: '/Malformed or truncated part/')]
   public function malformed_part_without_content_disposition() {
     iterator_to_array($this->parts(
       '--%1$s',
@@ -311,7 +311,7 @@ class PartsTest extends TestCase {
     ));
   }
 
-  #[Test, Expect(['class' => FormatException::class, 'withMessage' => '/Expected boundary ".+", have ""/'])]
+  #[Test, Expect(class: FormatException::class, message: '/Expected boundary ".+", have ""/')]
   public function missing_header_terminator() {
     iterator_to_array($this->parts(
       '--%1$s',
@@ -319,7 +319,7 @@ class PartsTest extends TestCase {
     ));
   }
 
-  #[Test, Expect(['class' => FormatException::class, 'withMessage' => '/Expected boundary ".+", have ""/'])]
+  #[Test, Expect(class: FormatException::class, message: '/Expected boundary ".+", have ""/')]
   public function missing_data() {
     iterator_to_array($this->parts(
       '--%1$s',
@@ -328,7 +328,7 @@ class PartsTest extends TestCase {
     ));
   }
 
-  #[Test, Expect(['class' => FormatException::class, 'withMessage' => '/Expected boundary ".+", have ""/'])]
+  #[Test, Expect(class: FormatException::class, message: '/Expected boundary ".+", have ""/')]
   public function missing_ending_delimiter() {
     iterator_to_array($this->parts(
       '--%1$s',
@@ -338,7 +338,7 @@ class PartsTest extends TestCase {
     ));
   }
 
-  #[Test, Expect(['class' => FormatException::class, 'withMessage' => '/Expected boundary ".+", have ""/'])]
+  #[Test, Expect(class: FormatException::class, message: '/Expected boundary ".+", have ""/')]
   public function mismatched_ending_delimiter() {
     iterator_to_array($this->parts(
       '--%1$s',
@@ -350,17 +350,17 @@ class PartsTest extends TestCase {
     ));
   }
 
-  #[Test, Expect(['class' => FormatException::class, 'withMessage' => '/Expected boundary ".+", have "--BEGIN"/'])]
+  #[Test, Expect(class: FormatException::class, message: '/Expected boundary ".+", have "--BEGIN"/')]
   public function mismatched_starting_delimiter() {
     iterator_to_array($this->parts('--BEGIN', ''));
   }
 
-  #[Test, Expect(['class' => FormatException::class, 'withMessage' => '/Expected boundary ".+", have ""/'])]
+  #[Test, Expect(class: FormatException::class, message: '/Expected boundary ".+", have ""/')]
   public function from_empty_line() {
     iterator_to_array($this->parts());
   }
 
-  #[Test, Expect(['class' => FormatException::class, 'withMessage' => '/Expected boundary ".+", have ""/'])]
+  #[Test, Expect(class: FormatException::class, message: '/Expected boundary ".+", have ""/')]
   public function from_empty_payload() {
     iterator_to_array($this->parts());
   }

--- a/src/test/php/web/unittest/io/ReadChunksTest.class.php
+++ b/src/test/php/web/unittest/io/ReadChunksTest.class.php
@@ -1,11 +1,11 @@
 <?php namespace web\unittest\io;
 
 use io\IOException;
-use unittest\{Expect, Test, TestCase, Values};
+use test\{Assert, Expect, Test, Values};
 use web\io\{ReadChunks, TestInput};
 use web\unittest\Chunking;
 
-class ReadChunksTest extends TestCase {
+class ReadChunksTest {
   use Chunking;
 
   /**
@@ -43,26 +43,26 @@ class ReadChunksTest extends TestCase {
   #[Test]
   public function available() {
     $fixture= new ReadChunks($this->input("4\r\nTest\r\n0\r\n\r\n"));
-    $this->assertEquals(4, $fixture->available());
+    Assert::equals(4, $fixture->available());
   }
 
   #[Test, Values([[2, 'Te', 2], [4, 'Test', 6], [6, 'Test', 6],])]
   public function available_after_reading($length, $read, $remaining) {
     $fixture= new ReadChunks($this->input("4\r\nTest\r\n6\r\nTested\r\n0\r\n\r\n"));
-    $this->assertEquals($read, $fixture->read($length));
-    $this->assertEquals($remaining, $fixture->available());
+    Assert::equals($read, $fixture->read($length));
+    Assert::equals($remaining, $fixture->available());
   }
 
   #[Test]
   public function available_last_chunk() {
     $fixture= new ReadChunks($this->input("0\r\n\r\n"));
-    $this->assertEquals(0, $fixture->available());
+    Assert::equals(0, $fixture->available());
   }
 
   #[Test]
   public function read() {
     $fixture= new ReadChunks($this->input("4\r\nTest\r\n0\r\n\r\n"));
-    $this->assertEquals('Test', $fixture->read());
+    Assert::equals('Test', $fixture->read());
   }
 
   #[Test, Values([["0\r\n\r\n", []], ["4\r\nTest\r\n0\r\n\r\n", ['Test']], ["4\r\nTest\r\n2\r\nOK\r\n0\r\n\r\n", ['Test', 'OK']], ["6\r\nTest\r\n\r\n0\r\n\r\n", ["Test\r\n"]], ["e\r\n{\"name\":\"PHP\"}\r\n0\r\n\r\n", ['{"name":"PHP"}']], ["F\r\n{\"name\":\"JSON\"}\r\n0\r\n\r\n", ['{"name":"JSON"}']],])]
@@ -72,7 +72,7 @@ class ReadChunksTest extends TestCase {
     while ($fixture->available()) {
       $r[]= $fixture->read();
     }
-    $this->assertEquals($expected, $r);
+    Assert::equals($expected, $r);
   }
 
   #[Test, Values([["0\r\n\r\n", []], ["4\r\nTest\r\n0\r\n\r\n", ['Test']], ["4\r\nTest\r\n3\r\n OK\r\n1\r\n!\r\n0\r\n\r\n", ['Test OK!']], ["1\r\n1\r\n2\r\n\r\n\r\n1\r\n2\r\n0\r\n\r\n", ['1', '2']]])]
@@ -82,7 +82,7 @@ class ReadChunksTest extends TestCase {
     while ($fixture->available()) {
       $r[]= $fixture->line();
     }
-    $this->assertEquals($expected, $r);
+    Assert::equals($expected, $r);
   }
 
   #[Test]
@@ -92,7 +92,7 @@ class ReadChunksTest extends TestCase {
     while ($fixture->available()) {
       $fixture->read();
     }
-    $this->assertEquals('', $input->read(-1));
+    Assert::equals('', $input->read(-1));
   }
 
   #[Test]
@@ -115,7 +115,7 @@ class ReadChunksTest extends TestCase {
       $fixture->read();
     }
 
-    $this->assertEquals(
+    Assert::equals(
       [
         'readLine:"4"', 'read:4:"Test"', 'readLine:""',
         'readLine:"2"', 'read:2:"ed"', 'readLine:""',
@@ -150,6 +150,6 @@ class ReadChunksTest extends TestCase {
   #[Test]
   public function close_is_a_noop() {
     $fixture= new ReadChunks($this->input("0\r\n\r\n"));
-    $this->assertNull($fixture->close());
+    Assert::null($fixture->close());
   }
 }

--- a/src/test/php/web/unittest/io/ReadLengthTest.class.php
+++ b/src/test/php/web/unittest/io/ReadLengthTest.class.php
@@ -1,10 +1,10 @@
 <?php namespace web\unittest\io;
 
 use io\IOException;
-use unittest\{Test, Values, TestCase};
+use test\{Assert, Test, Values};
 use web\io\{ReadLength, TestInput};
 
-class ReadLengthTest extends TestCase {
+class ReadLengthTest {
 
   /**
    * Creates an input instance
@@ -24,26 +24,26 @@ class ReadLengthTest extends TestCase {
   #[Test]
   public function available() {
     $fixture= new ReadLength($this->input('Test'), 4);
-    $this->assertEquals(4, $fixture->available());
+    Assert::equals(4, $fixture->available());
   }
 
   #[Test]
   public function read() {
     $fixture= new ReadLength($this->input('Test'), 4);
-    $this->assertEquals('Test', $fixture->read());
+    Assert::equals('Test', $fixture->read());
   }
 
   #[Test]
   public function available_when_empty() {
     $fixture= new ReadLength($this->input(''), 0);
-    $this->assertEquals(0, $fixture->available());
+    Assert::equals(0, $fixture->available());
   }
 
   #[Test]
   public function available_after_read() {
     $fixture= new ReadLength($this->input('Test'), 4);
     $fixture->read();
-    $this->assertEquals(0, $fixture->available());
+    Assert::equals(0, $fixture->available());
   }
 
   #[Test, Values([4, 8192])]
@@ -60,6 +60,6 @@ class ReadLengthTest extends TestCase {
   #[Test]
   public function close_is_a_noop() {
     $fixture= new ReadLength($this->input('Test'), 4);
-    $this->assertNull($fixture->close());
+    Assert::null($fixture->close());
   }
 }

--- a/src/test/php/web/unittest/io/ReadStreamTest.class.php
+++ b/src/test/php/web/unittest/io/ReadStreamTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace web\unittest\io;
 
-use unittest\{Test, TestCase};
+use test\{Assert, Test};
 use web\io\{ReadStream, TestInput};
 
-class ReadStreamTest extends TestCase {
+class ReadStreamTest {
 
   /**
    * Creates an input instance
@@ -23,18 +23,18 @@ class ReadStreamTest extends TestCase {
   #[Test]
   public function available() {
     $fixture= new ReadStream($this->input('Test'));
-    $this->assertEquals(1, $fixture->available());
+    Assert::equals(1, $fixture->available());
   }
 
   #[Test]
   public function read() {
     $fixture= new ReadStream($this->input('Test'));
-    $this->assertEquals('Test', $fixture->read());
+    Assert::equals('Test', $fixture->read());
   }
 
   #[Test]
   public function close_is_a_noop() {
     $fixture= new ReadStream($this->input('Test'));
-    $this->assertNull($fixture->close());
+    Assert::null($fixture->close());
   }
 }

--- a/src/test/php/web/unittest/io/StreamTest.class.php
+++ b/src/test/php/web/unittest/io/StreamTest.class.php
@@ -7,7 +7,7 @@ use test\{Assert, Expect, Test, Values};
 use web\io\{Part, Stream};
 
 class StreamTest {
-  const NAME = 'test.txt';
+  const NAME= 'test.txt';
 
   /**
    * Creates an iterable from given chunks
@@ -74,6 +74,20 @@ class StreamTest {
     yield ['/etc/passwd', 'passwd'];
     yield ['../test.txt', 'test.txt'];
     yield ['./test.txt', 'test.txt'];
+  }
+
+  /** @return iterable */
+  private function files() {
+    yield function($t) { return new File($t, 'target.txt'); };
+    yield function($t) { return new Path($t, 'target.txt'); };
+    yield function($t) { return $t->getURI().'target.txt'; };
+  }
+
+  /** @return iterable */
+  private function folders() {
+    yield function($t) { return $t; };
+    yield function($t) { return new Path($t); };
+    yield function($t) { return $t->getURI(); };
   }
 
   #[Test]
@@ -160,12 +174,12 @@ class StreamTest {
     }
   }
 
-  #[Test, Values(eval: '[[fn($t) => $t], [fn($t) => new Path($t)], [fn($t) => $t->getURI()]]')]
+  #[Test, Values(from: 'folders')]
   public function transmit_to_folder($target) {
     $this->assertTransmission(['test.txt' => 'Test'], $target);
   }
 
-  #[Test, Values(eval: '[[fn($t) => new File($t, "target.txt")], [fn($t) => new Path($t, "target.txt")], [fn($t) => $t->getURI()."target.txt"]]')]
+  #[Test, Values(from: 'files')]
   public function transmit_to_file($target) {
     $this->assertTransmission(['target.txt' => 'Test'], $target);
   }

--- a/src/test/php/web/unittest/io/StreamTest.class.php
+++ b/src/test/php/web/unittest/io/StreamTest.class.php
@@ -3,10 +3,10 @@
 use io\streams\{MemoryOutputStream, Streams};
 use io\{File, Files, Folder, IOException, Path};
 use lang\{Environment, IllegalArgumentException};
-use unittest\{Expect, Test, TestCase, Values};
+use test\{Assert, Expect, Test, Values};
 use web\io\{Part, Stream};
 
-class StreamTest extends TestCase {
+class StreamTest {
   const NAME = 'test.txt';
 
   /**
@@ -48,8 +48,8 @@ class StreamTest extends TestCase {
       foreach ($t->entries() as $name => $entry) {
         $contents[$name]= Files::read($entry->asFile());
       }
-      $this->assertEquals(4, $written);
-      $this->assertEquals($expected, $contents);
+      Assert::equals(4, $written);
+      Assert::equals($expected, $contents);
     } finally {
       $t->unlink();
     }
@@ -83,53 +83,53 @@ class StreamTest extends TestCase {
 
   #[Test]
   public function kind() {
-    $this->assertEquals(Part::FILE, $this->newFixture(self::NAME)->kind());
+    Assert::equals(Part::FILE, $this->newFixture(self::NAME)->kind());
   }
 
-  #[Test, Values('names')]
+  #[Test, Values(from: 'names')]
   public function name($name, $base) {
-    $this->assertEquals($base, $this->newFixture($name)->name());
+    Assert::equals($base, $this->newFixture($name)->name());
   }
 
-  #[Test, Values('names')]
+  #[Test, Values(from: 'names')]
   public function raw_name($name, $base) {
-    $this->assertEquals($name, $this->newFixture($name)->name(true));
+    Assert::equals($name, $this->newFixture($name)->name(true));
   }
 
   #[Test]
   public function type() {
-    $this->assertEquals('text/plain', $this->newFixture(self::NAME)->type());
+    Assert::equals('text/plain', $this->newFixture(self::NAME)->type());
   }
 
   #[Test]
   public function string_representation() {
-    $this->assertEquals('web.io.Stream("test", type= text/plain)', $this->newFixture('test')->toString());
+    Assert::equals('web.io.Stream("test", type= text/plain)', $this->newFixture('test')->toString());
   }
 
-  #[Test, Values('chunks')]
+  #[Test, Values(from: 'chunks')]
   public function bytes($chunks, $expected) {
-    $this->assertEquals($expected, $this->newFixture(self::NAME, ...$chunks)->bytes());
+    Assert::equals($expected, $this->newFixture(self::NAME, ...$chunks)->bytes());
   }
 
-  #[Test, Values('chunks')]
+  #[Test, Values(from: 'chunks')]
   public function read_all($chunks, $expected) {
-    $this->assertEquals($expected, Streams::readAll($this->newFixture(self::NAME, ...$chunks)));
+    Assert::equals($expected, Streams::readAll($this->newFixture(self::NAME, ...$chunks)));
   }
 
   #[Test]
   public function read_empty() {
     $fixture= $this->newFixture(self::NAME);
-    $this->assertNull($fixture->read());
+    Assert::null($fixture->read());
   }
 
   #[Test]
   public function read_after_end() {
     $fixture= $this->newFixture(self::NAME, 'a');
     $fixture->read();
-    $this->assertNull($fixture->read());
+    Assert::null($fixture->read());
   }
 
-  #[Test, Values('chunks')]
+  #[Test, Values(from: 'chunks')]
   public function transmit_to_outputstream($chunks, $expected) {
     $out= new MemoryOutputStream();
     $it= $this->newFixture(self::NAME, ...$chunks)->transmit($out);
@@ -137,8 +137,8 @@ class StreamTest extends TestCase {
       $it->next();
     }
 
-    $this->assertEquals(strlen($expected), $it->getReturn());
-    $this->assertEquals($expected, $out->bytes());
+    Assert::equals(strlen($expected), $it->getReturn());
+    Assert::equals($expected, $out->bytes());
   }
 
   #[Test, Expect(IOException::class)]
@@ -172,6 +172,6 @@ class StreamTest extends TestCase {
 
   #[Test]
   public function close_is_a_noop() {
-    $this->assertNull($this->newFixture(self::NAME)->close());
+    Assert::null($this->newFixture(self::NAME)->close());
   }
 }

--- a/src/test/php/web/unittest/io/TestInputTest.class.php
+++ b/src/test/php/web/unittest/io/TestInputTest.class.php
@@ -1,10 +1,10 @@
 <?php namespace web\unittest\io;
 
-use unittest\{Test, TestCase, Values};
+use test\{Assert, Test, Values};
 use web\io\TestInput;
 use web\unittest\Chunking;
 
-class TestInputTest extends TestCase {
+class TestInputTest {
   use Chunking;
 
   #[Test]
@@ -14,80 +14,80 @@ class TestInputTest extends TestCase {
 
   #[Test]
   public function version() {
-    $this->assertEquals('1.1', (new TestInput('GET', '/'))->version());
+    Assert::equals('1.1', (new TestInput('GET', '/'))->version());
   }
 
   #[Test]
   public function scheme() {
-    $this->assertEquals('http', (new TestInput('GET', '/'))->scheme());
+    Assert::equals('http', (new TestInput('GET', '/'))->scheme());
   }
 
   #[Test, Values(['GET', 'HEAD', 'POST'])]
   public function method($name) {
-    $this->assertEquals($name, (new TestInput($name, '/'))->method());
+    Assert::equals($name, (new TestInput($name, '/'))->method());
   }
 
   #[Test, Values(['/', '/test'])]
   public function uri($path) {
-    $this->assertEquals($path, (new TestInput('GET', $path))->uri());
+    Assert::equals($path, (new TestInput('GET', $path))->uri());
   }
 
   #[Test]
   public function headers_empty_by_default() {
-    $this->assertEquals([], (new TestInput('GET', '/'))->headers());
+    Assert::equals([], (new TestInput('GET', '/'))->headers());
   }
 
   #[Test]
   public function headers() {
     $headers= ['Host' => 'example.com'];
-    $this->assertEquals($headers, (new TestInput('GET', '/', $headers))->headers());
+    Assert::equals($headers, (new TestInput('GET', '/', $headers))->headers());
   }
 
   #[Test]
   public function body_empty_by_default() {
-    $this->assertEquals('', (new TestInput('GET', '/'))->read());
+    Assert::equals('', (new TestInput('GET', '/'))->read());
   }
 
   #[Test, Values(['', 'body'])]
   public function read($body) {
-    $this->assertEquals($body, (new TestInput('GET', '/', [], $body))->read());
+    Assert::equals($body, (new TestInput('GET', '/', [], $body))->read());
   }
 
   #[Test]
   public function reading_line() {
-    $this->assertEquals('line', (new TestInput('GET', '/', [], "line\r\n"))->readLine());
+    Assert::equals('line', (new TestInput('GET', '/', [], "line\r\n"))->readLine());
   }
 
   #[Test]
   public function reading_line_without_ending_crlf() {
-    $this->assertEquals('line', (new TestInput('GET', '/', [], "line"))->readLine());
+    Assert::equals('line', (new TestInput('GET', '/', [], "line"))->readLine());
   }
 
   #[Test]
   public function reading_lines() {
     $fixture= new TestInput('GET', '/', [], "line 1\r\nline 2\r\n");
-    $this->assertEquals('line 1', $fixture->readLine());
-    $this->assertEquals('line 2', $fixture->readLine());
-    $this->assertNull($fixture->readLine());
+    Assert::equals('line 1', $fixture->readLine());
+    Assert::equals('line 2', $fixture->readLine());
+    Assert::null($fixture->readLine());
   }
 
   #[Test]
   public function content_length_calculated() {
     $fixture= new TestInput('GET', '/', ['Content-Type' => 'text/plain'], 'Test');
-    $this->assertEquals(['Content-Type' => 'text/plain', 'Content-Length' => 4], $fixture->headers());
+    Assert::equals(['Content-Type' => 'text/plain', 'Content-Length' => 4], $fixture->headers());
   }
 
   #[Test]
   public function content_length_not_calculated_when_chunked() {
     $fixture= new TestInput('GET', '/', self::$CHUNKED, $this->chunked('Test'));
-    $this->assertEquals(self::$CHUNKED, $fixture->headers());
+    Assert::equals(self::$CHUNKED, $fixture->headers());
   }
 
   #[Test]
   public function body_can_be_passed_as_array() {
     $fixture= new TestInput('GET', '/', ['Accept' => '*/*'], ['key' => 'value']);
-    $this->assertEquals('key=value', $fixture->read());
-    $this->assertEquals(
+    Assert::equals('key=value', $fixture->read());
+    Assert::equals(
       ['Accept' => '*/*', 'Content-Type' => 'application/x-www-form-urlencoded', 'Content-Length' => 9],
       $fixture->headers()
     );

--- a/src/test/php/web/unittest/io/TestOutputTest.class.php
+++ b/src/test/php/web/unittest/io/TestOutputTest.class.php
@@ -1,10 +1,10 @@
 <?php namespace web\unittest\io;
 
 use lang\XPClass;
-use unittest\{Test, TestCase};
+use test\{Assert, Test, Values};
 use web\io\{Buffered, TestOutput};
 
-class TestOutputTest extends TestCase {
+class TestOutputTest {
 
   #[Test]
   public function can_create() {
@@ -15,21 +15,21 @@ class TestOutputTest extends TestCase {
   public function begin() {
     $fixture= new TestOutput();
     $fixture->begin(200, 'OK', []);
-    $this->assertEquals("HTTP/1.1 200 OK\r\n\r\n", $fixture->bytes());
+    Assert::equals("HTTP/1.1 200 OK\r\n\r\n", $fixture->bytes());
   }
 
   #[Test]
   public function begin_with_header() {
     $fixture= new TestOutput();
     $fixture->begin(200, 'OK', ['Server' => ['Test']]);
-    $this->assertEquals("HTTP/1.1 200 OK\r\nServer: Test\r\n\r\n", $fixture->bytes());
+    Assert::equals("HTTP/1.1 200 OK\r\nServer: Test\r\n\r\n", $fixture->bytes());
   }
 
   #[Test]
   public function begin_with_404_status() {
     $fixture= new TestOutput();
     $fixture->begin(404, 'Not Found', []);
-    $this->assertEquals("HTTP/1.1 404 Not Found\r\n\r\n", $fixture->bytes());
+    Assert::equals("HTTP/1.1 404 Not Found\r\n\r\n", $fixture->bytes());
   }
 
   #[Test]
@@ -37,28 +37,28 @@ class TestOutputTest extends TestCase {
     $fixture= new TestOutput();
     $fixture->begin(200, 'OK', ['Content-Length' => [4]]);
     $fixture->write('Test');
-    $this->assertEquals("HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nTest", $fixture->bytes());
+    Assert::equals("HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nTest", $fixture->bytes());
   }
 
   #[Test]
   public function start() {
     $fixture= new TestOutput();
     $fixture->begin(200, 'OK', []);
-    $this->assertEquals('HTTP/1.1 200 OK', $fixture->start());
+    Assert::equals('HTTP/1.1 200 OK', $fixture->start());
   }
 
   #[Test]
   public function empty_headers() {
     $fixture= new TestOutput();
     $fixture->begin(200, 'OK', []);
-    $this->assertEquals('', $fixture->headers());
+    Assert::equals('', $fixture->headers());
   }
 
   #[Test]
   public function headers() {
     $fixture= new TestOutput();
     $fixture->begin(200, 'OK', ['Server' => ['Test'], 'Cache-control' => ['no-cache']]);
-    $this->assertEquals("Server: Test\r\nCache-control: no-cache", $fixture->headers());
+    Assert::equals("Server: Test\r\nCache-control: no-cache", $fixture->headers());
   }
 
   #[Test]
@@ -66,7 +66,7 @@ class TestOutputTest extends TestCase {
     $fixture= new TestOutput();
     $fixture->begin(200, 'OK', ['Content-Length' => [4]]);
     $fixture->write('Test');
-    $this->assertEquals('Test', $fixture->body());
+    Assert::equals('Test', $fixture->body());
   }
 
   #[Test]
@@ -77,7 +77,7 @@ class TestOutputTest extends TestCase {
       $stream->write('Hello');
       $stream->write('Test');
     });
-    $this->assertEquals(
+    Assert::equals(
       "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n9\r\nHelloTest\r\n0\r\n\r\n",
       $fixture->bytes()
     );
@@ -91,7 +91,7 @@ class TestOutputTest extends TestCase {
       $stream->write('Hello');
       $stream->write('Test');
     });
-    $this->assertEquals(
+    Assert::equals(
       "HTTP/1.1 200 OK\r\nContent-Length: 9\r\n\r\nHelloTest",
       $fixture->bytes()
     );
@@ -105,7 +105,7 @@ class TestOutputTest extends TestCase {
       $stream->write('Hello');
       $stream->write('Test');
     });
-    $this->assertEquals(
+    Assert::equals(
       "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n9\r\nHelloTest\r\n0\r\n\r\n",
       $fixture->bytes()
     );
@@ -119,7 +119,7 @@ class TestOutputTest extends TestCase {
       $stream->write('Hello');
       $stream->write('Test');
     });
-    $this->assertEquals(
+    Assert::equals(
       "HTTP/1.1 200 OK\r\nContent-Length: 9\r\n\r\nHelloTest",
       $fixture->bytes()
     );

--- a/src/test/php/web/unittest/io/WriteChunksTest.class.php
+++ b/src/test/php/web/unittest/io/WriteChunksTest.class.php
@@ -1,9 +1,10 @@
 <?php namespace web\unittest\io;
 
-use unittest\Test;
+use test\Assert;
+use test\Test;
 use web\io\{TestOutput, WriteChunks};
 
-class WriteChunksTest extends \unittest\TestCase {
+class WriteChunksTest {
 
   #[Test]
   public function can_create() {
@@ -18,7 +19,7 @@ class WriteChunksTest extends \unittest\TestCase {
     $w->write('Test');
     $w->finish();
 
-    $this->assertEquals("4\r\nTest\r\n0\r\n\r\n", $out->bytes());
+    Assert::equals("4\r\nTest\r\n0\r\n\r\n", $out->bytes());
   }
 
   #[Test]
@@ -30,7 +31,7 @@ class WriteChunksTest extends \unittest\TestCase {
     $w->write('Test');
     $w->finish();
 
-    $this->assertEquals("8\r\nUnitTest\r\n0\r\n\r\n", $out->bytes());
+    Assert::equals("8\r\nUnitTest\r\n0\r\n\r\n", $out->bytes());
   }
 
   #[Test]
@@ -43,6 +44,6 @@ class WriteChunksTest extends \unittest\TestCase {
     $w->write('Test');
     $w->finish();
 
-    $this->assertEquals("1001\r\n".$chunk."\r\n4\r\nTest\r\n0\r\n\r\n", $out->bytes());
+    Assert::equals("1001\r\n".$chunk."\r\n4\r\nTest\r\n0\r\n\r\n", $out->bytes());
   }
 }

--- a/src/test/php/web/unittest/logging/SinkTest.class.php
+++ b/src/test/php/web/unittest/logging/SinkTest.class.php
@@ -1,37 +1,37 @@
 <?php namespace web\unittest\logging;
 
 use io\TempFile;
-use unittest\{Test, TestCase, Values};
+use test\{Assert, Test, Values};
 use util\log\LogCategory;
-use web\logging\{Sink, ToAllOf, ToConsole, ToFile, ToFunction, ToCategory};
+use web\logging\{Sink, ToAllOf, ToCategory, ToConsole, ToFile, ToFunction};
 
-class SinkTest extends TestCase {
+class SinkTest {
 
   #[Test, Values([[null], [[]]])]
   public function no_logging($arg) {
-    $this->assertNull(Sink::of($arg));
+    Assert::null(Sink::of($arg));
   }
 
   #[Test]
   public function logging_to_console() {
-    $this->assertInstanceOf(ToConsole::class, Sink::of('-'));
+    Assert::instance(ToConsole::class, Sink::of('-'));
   }
 
   #[Test]
   public function logging_to_function() {
-    $this->assertInstanceOf(ToFunction::class, Sink::of(function($req, $res, $error) { }));
+    Assert::instance(ToFunction::class, Sink::of(function($req, $res, $error) { }));
   }
 
   #[Test]
   public function logging_to_category() {
-    $this->assertInstanceOf(ToCategory::class, Sink::of(new LogCategory('test')));
+    Assert::instance(ToCategory::class, Sink::of(new LogCategory('test')));
   }
 
   #[Test]
   public function logging_to_file() {
     $t= new TempFile('log');
     try {
-      $this->assertInstanceOf(ToFile::class, Sink::of($t));
+      Assert::instance(ToFile::class, Sink::of($t));
     } finally {
       $t->unlink();
     }
@@ -41,7 +41,7 @@ class SinkTest extends TestCase {
   public function logging_to_file_by_name() {
     $t= new TempFile('log');
     try {
-      $this->assertInstanceOf(ToFile::class, Sink::of($t->getURI()));
+      Assert::instance(ToFile::class, Sink::of($t->getURI()));
     } finally {
       $t->unlink();
     }
@@ -51,7 +51,7 @@ class SinkTest extends TestCase {
   public function logging_to_all_of() {
     $t= new TempFile('log');
     try {
-      $this->assertInstanceOf(ToAllOf::class, Sink::of(['-', $t]));
+      Assert::instance(ToAllOf::class, Sink::of(['-', $t]));
     } finally {
       $t->unlink();
     }
@@ -59,6 +59,6 @@ class SinkTest extends TestCase {
 
   #[Test]
   public function logging_to_all_of_flattened_when_only_one_argument_passed() {
-    $this->assertInstanceOf(ToConsole::class, Sink::of(['-']));
+    Assert::instance(ToConsole::class, Sink::of(['-']));
   }
 }

--- a/src/test/php/web/unittest/logging/ToAllOfTest.class.php
+++ b/src/test/php/web/unittest/logging/ToAllOfTest.class.php
@@ -1,11 +1,11 @@
 <?php namespace web\unittest\logging;
 
-use unittest\{Test, TestCase, Values};
+use test\{Assert, Test, Values};
 use web\io\{TestInput, TestOutput};
 use web\logging\{ToAllOf, ToConsole, ToFunction};
 use web\{Error, Request, Response};
 
-class ToAllOfTest extends TestCase {
+class ToAllOfTest {
 
   /** @return iterable */
   private function arguments() {
@@ -32,29 +32,29 @@ class ToAllOfTest extends TestCase {
   public function sinks() {
     $a= new ToConsole();
     $b= new ToFunction(function($req, $res, $error) {  });
-    $this->assertEquals([$a, $b], (new ToAllOf($a, $b))->sinks());
+    Assert::equals([$a, $b], (new ToAllOf($a, $b))->sinks());
   }
 
   #[Test]
   public function sinks_are_merged_when_passed_ToAllOf_instance() {
     $a= new ToConsole();
     $b= new ToFunction(function($req, $res, $error) {  });
-    $this->assertEquals([$a, $b], (new ToAllOf(new ToAllOf($a, $b)))->sinks());
+    Assert::equals([$a, $b], (new ToAllOf(new ToAllOf($a, $b)))->sinks());
   }
 
   #[Test]
   public function sinks_are_empty_when_created_without_arg() {
-    $this->assertEquals([], (new ToAllOf())->sinks());
+    Assert::equals([], (new ToAllOf())->sinks());
   }
 
   #[Test]
   public function targets() {
     $a= new ToConsole();
     $b= new ToFunction(function($req, $res, $error) { });
-    $this->assertEquals('(web.logging.ToConsole & web.logging.ToFunction)', (new ToAllOf($a, $b))->target());
+    Assert::equals('(web.logging.ToConsole & web.logging.ToFunction)', (new ToAllOf($a, $b))->target());
   }
 
-  #[Test, Values('arguments')]
+  #[Test, Values(from: 'arguments')]
   public function logs_to_all($expected, $error) {
     $req= new Request(new TestInput('GET', '/'));
     $res= new Response(new TestOutput());
@@ -70,6 +70,6 @@ class ToAllOfTest extends TestCase {
     );
     $sink->log($req, $res, $error);
 
-    $this->assertEquals($expected, $logged);
+    Assert::equals($expected, $logged);
   }
 }

--- a/src/test/php/web/unittest/logging/ToCategoryTest.class.php
+++ b/src/test/php/web/unittest/logging/ToCategoryTest.class.php
@@ -1,12 +1,12 @@
 <?php namespace web\unittest\logging;
 
-use unittest\{Test, TestCase};
-use util\log\{LogCategory, BufferedAppender};
+use test\{Assert, Test};
+use util\log\{BufferedAppender, LogCategory};
 use web\io\{TestInput, TestOutput};
 use web\logging\ToCategory;
 use web\{Error, Request, Response};
 
-class ToCategoryTest extends TestCase {
+class ToCategoryTest {
 
   #[Test]
   public function can_create() {
@@ -16,7 +16,7 @@ class ToCategoryTest extends TestCase {
   #[Test]
   public function target() {
     $cat= new LogCategory('test');
-    $this->assertEquals('web.logging.ToCategory('.$cat->toString().')', (new ToCategory($cat))->target());
+    Assert::equals('web.logging.ToCategory('.$cat->toString().')', (new ToCategory($cat))->target());
   }
 
   #[Test]
@@ -27,7 +27,7 @@ class ToCategoryTest extends TestCase {
     $buffered= new BufferedAppender();
     (new ToCategory((new LogCategory('test'))->withAppender($buffered)))->log($req, $res, null);
 
-    $this->assertNotEquals(0, strlen($buffered->getBuffer()));
+    Assert::notEquals(0, strlen($buffered->getBuffer()));
   }
 
   #[Test]
@@ -38,6 +38,6 @@ class ToCategoryTest extends TestCase {
     $buffered= new BufferedAppender();
     (new ToCategory((new LogCategory('test'))->withAppender($buffered)))->log($req, $res, new Error(404, 'Test'));
 
-    $this->assertNotEquals(0, strlen($buffered->getBuffer()));
+    Assert::notEquals(0, strlen($buffered->getBuffer()));
   }
 }

--- a/src/test/php/web/unittest/logging/ToConsoleTest.class.php
+++ b/src/test/php/web/unittest/logging/ToConsoleTest.class.php
@@ -1,13 +1,13 @@
 <?php namespace web\unittest\logging;
 
 use io\streams\MemoryOutputStream;
-use unittest\{Test, TestCase};
+use test\{Assert, Test};
 use util\cmd\Console;
 use web\io\{TestInput, TestOutput};
 use web\logging\ToConsole;
 use web\{Error, Request, Response};
 
-class ToConsoleTest extends TestCase {
+class ToConsoleTest {
 
   /** 
    * Log a message
@@ -38,11 +38,11 @@ class ToConsoleTest extends TestCase {
 
   #[Test]
   public function log_without_error() {
-    $this->assertNotEquals(0, strlen($this->log(null)));
+    Assert::notEquals(0, strlen($this->log(null)));
   }
 
   #[Test]
   public function log_with_error() {
-    $this->assertNotEquals(0, strlen($this->log(new Error(404, 'Test'))));
+    Assert::notEquals(0, strlen($this->log(new Error(404, 'Test'))));
   }
 }

--- a/src/test/php/web/unittest/routing/PathTest.class.php
+++ b/src/test/php/web/unittest/routing/PathTest.class.php
@@ -1,14 +1,15 @@
 <?php namespace web\unittest\routing;
 
-use unittest\{Test, Values};
+use test\Assert;
+use test\{Test, Values};
 use web\Request;
 use web\io\TestInput;
 use web\routing\Path;
 
-class PathTest extends \unittest\TestCase {
+class PathTest {
 
   #[Test, Values([['/test', true], ['/test/', true], ['/test/the/west', true], ['/test.html', false], ['/TEST', false], ['/not/test', false], ['/', false]])]
   public function matches($path, $expected) {
-    $this->assertEquals($expected, (new Path('/test'))->matches(new Request(new TestInput('GET', $path))));
+    Assert::equals($expected, (new Path('/test'))->matches(new Request(new TestInput('GET', $path))));
   }
 }

--- a/src/test/php/web/unittest/routing/TargetTest.class.php
+++ b/src/test/php/web/unittest/routing/TargetTest.class.php
@@ -1,25 +1,25 @@
 <?php namespace web\unittest\routing;
 
-use unittest\{Test, Values, TestCase};
+use test\{Assert, Test, Values};
 use web\Request;
 use web\io\TestInput;
-use web\routing\{Target, RouteMatch};
+use web\routing\{RouteMatch, Target};
 
-class TargetTest extends TestCase {
+class TargetTest {
 
   #[Test, Values([['CONNECT', true], ['POST', false]])]
   public function method($method, $expected) {
-    $this->assertEquals($expected, (new Target('CONNECT', '*'))->matches(new Request(new TestInput($method, '/'))));
+    Assert::equals($expected, (new Target('CONNECT', '*'))->matches(new Request(new TestInput($method, '/'))));
   }
 
   #[Test, Values([['GET', true], ['HEAD', true], ['POST', false]])]
   public function methods($method, $expected) {
-    $this->assertEquals($expected, (new Target(['GET', 'HEAD'], '*'))->matches(new Request(new TestInput($method, '/'))));
+    Assert::equals($expected, (new Target(['GET', 'HEAD'], '*'))->matches(new Request(new TestInput($method, '/'))));
   }
 
   #[Test, Values([['GET', '/test', true], ['GET', '/test/', true], ['GET', '/test/the/west', true], ['GET', '/test.html', false], ['GET', '/TEST', false], ['GET', '/', false], ['POST', '/test', false], ['POST', '/', false]])]
   public function method_and_path($method, $path, $expected) {
-    $this->assertEquals($expected, (new Target('GET', '/test'))->matches(new Request(new TestInput($method, $path))));
+    Assert::equals($expected, (new Target('GET', '/test'))->matches(new Request(new TestInput($method, $path))));
   }
 
   #[Test, Values([[['X-Match' => 'yes'], true], [[], false]])]
@@ -27,6 +27,6 @@ class TargetTest extends TestCase {
     $match= new class() implements RouteMatch {
       public function matches($request) { return null !== $request->header('X-Match'); }
     };
-    $this->assertEquals($expected, (new Target('GET', $match))->matches(new Request(new TestInput('GET', '/', $headers))));
+    Assert::equals($expected, (new Target('GET', $match))->matches(new Request(new TestInput('GET', '/', $headers))));
   }
 }

--- a/src/test/php/web/unittest/server/InputTest.class.php
+++ b/src/test/php/web/unittest/server/InputTest.class.php
@@ -2,10 +2,10 @@
 
 use io\streams\Streams;
 use peer\{Socket, SocketEndpoint};
-use unittest\{Test, TestCase};
+use test\{Assert, Test, Values};
 use xp\web\srv\Input;
 
-class InputTest extends TestCase {
+class InputTest {
 
   /**
    * Returns a socket which can be read from
@@ -47,43 +47,43 @@ class InputTest extends TestCase {
 
   #[Test]
   public function close_kind() {
-    $this->assertEquals(Input::CLOSE, (new Input($this->socket('')))->kind);
+    Assert::equals(Input::CLOSE, (new Input($this->socket('')))->kind);
   }
 
   #[Test]
   public function request_kind() {
-    $this->assertEquals(Input::REQUEST, (new Input($this->socket("GET / HTTP/1.1\r\n\r\n")))->kind);
+    Assert::equals(Input::REQUEST, (new Input($this->socket("GET / HTTP/1.1\r\n\r\n")))->kind);
   }
 
   #[Test]
   public function malformed_kind() {
-    $this->assertEquals('EHLO example.org', (new Input($this->socket("EHLO example.org\r\n")))->kind);
+    Assert::equals('EHLO example.org', (new Input($this->socket("EHLO example.org\r\n")))->kind);
   }
 
   #[Test]
   public function http_scheme_default() {
-    $this->assertEquals('http', (new Input($this->socket("GET / HTTP/1.1\r\n\r\n")))->scheme());
+    Assert::equals('http', (new Input($this->socket("GET / HTTP/1.1\r\n\r\n")))->scheme());
   }
 
   #[Test]
   public function method() {
-    $this->assertEquals('GET', (new Input($this->socket("GET / HTTP/1.1\r\n\r\n")))->method());
+    Assert::equals('GET', (new Input($this->socket("GET / HTTP/1.1\r\n\r\n")))->method());
   }
 
   #[Test]
   public function uri() {
-    $this->assertEquals('/', (new Input($this->socket("GET / HTTP/1.1\r\n\r\n")))->uri());
+    Assert::equals('/', (new Input($this->socket("GET / HTTP/1.1\r\n\r\n")))->uri());
   }
 
   #[Test]
   public function version() {
-    $this->assertEquals('1.1', (new Input($this->socket("GET / HTTP/1.1\r\n\r\n")))->version());
+    Assert::equals('1.1', (new Input($this->socket("GET / HTTP/1.1\r\n\r\n")))->version());
   }
 
   #[Test]
   public function no_headers() {
     $input= new Input($this->socket("GET / HTTP/1.1\r\n\r\n"));
-    $this->assertEquals(
+    Assert::equals(
       ['Remote-Addr' => '127.0.0.1'],
       iterator_to_array($input->headers())
     );
@@ -92,7 +92,7 @@ class InputTest extends TestCase {
   #[Test]
   public function headers() {
     $input= new Input($this->socket("GET / HTTP/1.1\r\nHost: example\r\nDate: Tue, 15 Nov 1994 08:12:31 GMT\r\n\r\n"));
-    $this->assertEquals(
+    Assert::equals(
       ['Remote-Addr' => '127.0.0.1', 'Host' => 'example', 'Date' => 'Tue, 15 Nov 1994 08:12:31 GMT'],
       iterator_to_array($input->headers())
     );
@@ -103,7 +103,7 @@ class InputTest extends TestCase {
     $input= new Input($this->socket("GET / HTTP/1.1\r\n\r\n"));
     iterator_count($input->headers());
 
-    $this->assertNull($input->incoming());
+    Assert::null($input->incoming());
   }
 
   #[Test]
@@ -111,7 +111,7 @@ class InputTest extends TestCase {
     $input= new Input($this->socket("POST / HTTP/1.1\r\nContent-Length: 4\r\n\r\nTest"));
     iterator_count($input->headers());
 
-    $this->assertEquals('Test', Streams::readAll($input->incoming()));
+    Assert::equals('Test', Streams::readAll($input->incoming()));
   }
 
   #[Test]
@@ -119,7 +119,7 @@ class InputTest extends TestCase {
     $input= new Input($this->socket("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nTest\r\n0\r\n\r\n"));
     iterator_count($input->headers());
 
-    $this->assertEquals('Test', Streams::readAll($input->incoming()));
+    Assert::equals('Test', Streams::readAll($input->incoming()));
   }
 
   #[Test]
@@ -127,7 +127,7 @@ class InputTest extends TestCase {
     $input= new Input($this->socket("POST / HTTP/1.1\r\nContent-Length: 4\r\n\r\nTest"));
     iterator_count($input->headers());
 
-    $this->assertEquals('Test', $input->read(4));
+    Assert::equals('Test', $input->read(4));
   }
 
   #[Test]
@@ -135,7 +135,7 @@ class InputTest extends TestCase {
     $input= new Input($this->socket("POST / HTTP/1.1\r\nContent-Length: 4\r\n\r\nTest"));
     iterator_count($input->headers());
 
-    $this->assertEquals('Test', $input->read(-1));
+    Assert::equals('Test', $input->read(-1));
   }
 
   #[Test, Values([1024, 4096, 8192])]
@@ -144,6 +144,6 @@ class InputTest extends TestCase {
     $input= new Input($this->socket("GET / HTTP/1.1\r\nCookie: {$header}\r\n\r\n"));
     $headers= iterator_to_array($input->headers());
 
-    $this->assertEquals($header, $headers['Cookie']);
+    Assert::equals($header, $headers['Cookie']);
   }
 }

--- a/src/test/php/web/unittest/server/SAPITest.class.php
+++ b/src/test/php/web/unittest/server/SAPITest.class.php
@@ -2,11 +2,11 @@
 
 use io\OperationNotSupportedException;
 use io\streams\{MemoryInputStream, Streams};
-use unittest\{Expect, Test, TestCase, Values};
+use test\{Assert, Expect, Test, Values};
 use web\io\{ReadLength, ReadStream};
 use xp\web\SAPI;
 
-class SAPITest extends TestCase {
+class SAPITest {
   const BOUNDARY = '------------------------899f0c287170dd63';
 
   /**
@@ -69,37 +69,37 @@ class SAPITest extends TestCase {
 
   #[Test]
   public function http_scheme_default() {
-    $this->assertEquals('http', (new SAPI())->scheme());
+    Assert::equals('http', (new SAPI())->scheme());
   }
 
   #[Test, Values(['on', 'ON', '1'])]
   public function https_scheme_via_https_server_entry($value) {
     $_SERVER['HTTPS']= $value;
-    $this->assertEquals('https', (new SAPI())->scheme());
+    Assert::equals('https', (new SAPI())->scheme());
   }
 
   #[Test, Values(['off', 'OFF', '0'])]
   public function http_scheme_via_https_server_entry($value) {
     $_SERVER['HTTPS']= $value;
-    $this->assertEquals('http', (new SAPI())->scheme());
+    Assert::equals('http', (new SAPI())->scheme());
   }
 
   #[Test, Values(['GET', 'POST', 'OPTIONS'])]
   public function method($value) {
     $_SERVER['REQUEST_METHOD']= $value;
-    $this->assertEquals($value, (new SAPI())->method());
+    Assert::equals($value, (new SAPI())->method());
   }
 
   #[Test]
   public function uri() {
     $_SERVER['REQUEST_URI']= '/favicon.ico';
-    $this->assertEquals('/favicon.ico', (new SAPI())->uri());
+    Assert::equals('/favicon.ico', (new SAPI())->uri());
   }
 
   #[Test]
   public function version() {
     $_SERVER['SERVER_PROTOCOL']= 'HTTP/1.1';
-    $this->assertEquals('1.1', (new SAPI())->version());
+    Assert::equals('1.1', (new SAPI())->version());
   }
 
   #[Test]
@@ -109,7 +109,7 @@ class SAPITest extends TestCase {
 
     $fixture= new SAPI();
     iterator_count($fixture->headers());
-    $this->assertInstanceOf(ReadStream::class, $fixture->incoming());
+    Assert::instance(ReadStream::class, $fixture->incoming());
   }
 
   #[Test]
@@ -119,18 +119,18 @@ class SAPITest extends TestCase {
 
     $fixture= new SAPI();
     iterator_count($fixture->headers());
-    $this->assertInstanceOf(ReadLength::class, $fixture->incoming());
+    Assert::instance(ReadLength::class, $fixture->incoming());
   }
 
   #[Test]
   public function parts_without_files() {
     $_FILES= [];
-    $this->assertEquals([], iterator_to_array((new SAPI())->parts(self::BOUNDARY)));
+    Assert::equals([], iterator_to_array((new SAPI())->parts(self::BOUNDARY)));
   }
 
   #[Test]
   public function successful_upload() {
-    $this->assertEquals(['file' => 'xp.web.Upload'], array_map(
+    Assert::equals(['file' => 'xp.web.Upload'], array_map(
       function($part) { return nameof($part); },
       $this->parts($this->upload('test.txt', 'text/plain'))
     ));
@@ -138,7 +138,7 @@ class SAPITest extends TestCase {
 
   #[Test]
   public function successful_upload_with_array_parameter() {
-    $this->assertEquals(['file[]' => 'xp.web.Upload'], array_map(
+    Assert::equals(['file[]' => 'xp.web.Upload'], array_map(
       function($part) { return nameof($part); },
       $this->parts(function($uri) {
         return [
@@ -157,30 +157,30 @@ class SAPITest extends TestCase {
   #[Test]
   public function upload_name() {
     $parts= $this->parts($this->upload('test.txt', 'text/plain'));
-    $this->assertEquals('test.txt', $parts['file']->name());
+    Assert::equals('test.txt', $parts['file']->name());
   }
 
   #[Test]
   public function upload_type() {
     $parts= $this->parts($this->upload('test.txt', 'text/plain'));
-    $this->assertEquals('text/plain', $parts['file']->type());
+    Assert::equals('text/plain', $parts['file']->type());
   }
 
   #[Test]
   public function read_part() {
     $parts= $this->parts($this->upload('test.txt', 'text/plain'));
-    $this->assertEquals('Test', $parts['file']->bytes());
+    Assert::equals('Test', $parts['file']->bytes());
   }
 
   #[Test]
   public function use_part_as_stream() {
     $parts= $this->parts($this->upload('test.txt', 'text/plain'));
-    $this->assertEquals('Test', Streams::readAll($parts['file']));
+    Assert::equals('Test', Streams::readAll($parts['file']));
   }
 
   #[Test]
   public function upload_exceeding_ini_size() {
-    $this->assertEquals(['file' => 'web.io.Incomplete("test.txt", error= ERR_INI_SIZE)'], array_map(
+    Assert::equals(['file' => 'web.io.Incomplete("test.txt", error= ERR_INI_SIZE)'], array_map(
       function($part) { return $part->toString(); },
       $this->parts($this->incomplete('test.txt', UPLOAD_ERR_INI_SIZE))
     ));
@@ -188,7 +188,7 @@ class SAPITest extends TestCase {
 
   #[Test]
   public function upload_without_file() {
-    $this->assertEquals(['file' => 'web.io.Incomplete("", error= ERR_NO_FILE)'], array_map(
+    Assert::equals(['file' => 'web.io.Incomplete("", error= ERR_NO_FILE)'], array_map(
       function($part) { return $part->toString(); },
       $this->parts($this->incomplete('', UPLOAD_ERR_NO_FILE))
     ));
@@ -209,7 +209,7 @@ class SAPITest extends TestCase {
   #[Test]
   public function parameters_yielded_by_parts() {
     $_REQUEST= ['submit' => 'Test'];
-    $this->assertEquals(['submit' => 'web.io.Param', 'file' => 'xp.web.Upload'], array_map(
+    Assert::equals(['submit' => 'web.io.Param', 'file' => 'xp.web.Upload'], array_map(
       function($part) { return nameof($part); },
       $this->parts($this->upload('test.txt', 'text/plain'))
     ));
@@ -220,6 +220,6 @@ class SAPITest extends TestCase {
     $_REQUEST= ['varname' => 'the value'];
     $fixture= new SAPI();
     $parts = iterator_to_array($fixture->parts(''));
-    $this->assertEquals('the value', $parts['varname']->value());
+    Assert::equals('the value', $parts['varname']->value());
   }
 }

--- a/src/test/php/web/unittest/server/ServersTest.class.php
+++ b/src/test/php/web/unittest/server/ServersTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace web\unittest\server;
 
 use lang\IllegalArgumentException;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 use xp\web\Servers;
 
 class ServersTest {
@@ -14,7 +14,7 @@ class ServersTest {
     yield ['develop', Servers::$DEVELOP];
   }
 
-  #[Test, Values('servers')]
+  #[Test, Values(from: 'servers')]
   public function named($name, $expected) {
     Assert::equals($expected, Servers::named($name));
   }
@@ -29,7 +29,7 @@ class ServersTest {
     Assert::equals(Servers::$ASYNC, Servers::named('serve'));
   }
 
-  #[Test, Expect(class: IllegalArgumentException::class, withMessage: '/Unknown server "unknown", supported: .+/')]
+  #[Test, Expect(class: IllegalArgumentException::class, message: '/Unknown server "unknown", supported: .+/')]
   public function unknown_server() {
     Servers::named('unknown');
   }

--- a/src/test/php/web/unittest/server/UploadTest.class.php
+++ b/src/test/php/web/unittest/server/UploadTest.class.php
@@ -3,11 +3,11 @@
 use io\streams\{MemoryInputStream, MemoryOutputStream, Streams};
 use io\{File, Files, Folder, IOException, Path, TempFile};
 use lang\{Environment, IllegalArgumentException};
-use unittest\{Expect, Test, TestCase, Values};
+use test\{Assert, Expect, Test, Values};
 use web\io\Part;
 use xp\web\Upload;
 
-class UploadTest extends TestCase {
+class UploadTest {
   const NAME = 'test.txt';
 
   /**
@@ -42,8 +42,8 @@ class UploadTest extends TestCase {
       foreach ($t->entries() as $name => $entry) {
         $contents[$name]= Files::read($entry->asFile());
       }
-      $this->assertEquals(4, $written);
-      $this->assertEquals($expected, $contents);
+      Assert::equals(4, $written);
+      Assert::equals($expected, $contents);
     } finally {
       $t->unlink();
     }
@@ -56,22 +56,22 @@ class UploadTest extends TestCase {
 
   #[Test]
   public function kind() {
-    $this->assertEquals(Part::FILE, $this->newFixture(self::NAME)->kind());
+    Assert::equals(Part::FILE, $this->newFixture(self::NAME)->kind());
   }
 
   #[Test]
   public function name() {
-    $this->assertEquals(self::NAME, $this->newFixture(self::NAME)->name());
+    Assert::equals(self::NAME, $this->newFixture(self::NAME)->name());
   }
 
   #[Test]
   public function type() {
-    $this->assertEquals('text/plain', $this->newFixture(self::NAME)->type());
+    Assert::equals('text/plain', $this->newFixture(self::NAME)->type());
   }
 
   #[Test]
   public function string_representation() {
-    $this->assertEquals(
+    Assert::equals(
       'xp.web.Upload("test.txt", type= text/plain, source= /tmp/upload)',
       $this->newFixture(self::NAME, '/tmp/upload')->toString()
     );
@@ -80,13 +80,13 @@ class UploadTest extends TestCase {
   #[Test]
   public function bytes() {
     $source= Streams::readableUri(new MemoryInputStream('Test'));
-    $this->assertEquals('Test', $this->newFixture(self::NAME, $source)->bytes());
+    Assert::equals('Test', $this->newFixture(self::NAME, $source)->bytes());
   }
 
   #[Test]
   public function read_all() {
     $source= Streams::readableUri(new MemoryInputStream('Test'));
-    $this->assertEquals('Test', Streams::readAll($this->newFixture(self::NAME, $source)));
+    Assert::equals('Test', Streams::readAll($this->newFixture(self::NAME, $source)));
   }
 
   #[Test]
@@ -99,8 +99,8 @@ class UploadTest extends TestCase {
       $it->next();
     }
 
-    $this->assertEquals(4, $it->getReturn());
-    $this->assertEquals('Test', $out->bytes());
+    Assert::equals(4, $it->getReturn());
+    Assert::equals('Test', $out->bytes());
   }
 
   #[Test, Expect(IOException::class)]

--- a/src/test/php/web/unittest/server/UploadTest.class.php
+++ b/src/test/php/web/unittest/server/UploadTest.class.php
@@ -8,7 +8,7 @@ use web\io\Part;
 use xp\web\Upload;
 
 class UploadTest {
-  const NAME = 'test.txt';
+  const NAME= 'test.txt';
 
   /**
    * Creates a new fixture with given chunks
@@ -47,6 +47,20 @@ class UploadTest {
     } finally {
       $t->unlink();
     }
+  }
+
+  /** @return iterable */
+  private function files() {
+    yield function($t) { return new File($t, 'target.txt'); };
+    yield function($t) { return new Path($t, 'target.txt'); };
+    yield function($t) { return $t->getURI().'target.txt'; };
+  }
+
+  /** @return iterable */
+  private function folders() {
+    yield function($t) { return $t; };
+    yield function($t) { return new Path($t); };
+    yield function($t) { return $t->getURI(); };
   }
 
   #[Test]
@@ -124,12 +138,12 @@ class UploadTest {
     }
   }
 
-  #[Test, Values(eval: '[[fn($t) => $t], [fn($t) => new Path($t)], [fn($t) => $t->getURI()]]')]
+  #[Test, Values(from: 'folders')]
   public function transmit_to_folder($target) {
     $this->assertTransmission(['test.txt' => 'Test'], $target);
   }
 
-  #[Test, Values(eval: '[[fn($t) => new File($t, "target.txt")], [fn($t) => new Path($t, "target.txt")], [fn($t) => $t->getURI()."target.txt"]]')]
+  #[Test, Values(from: 'files')]
   public function transmit_to_file($target) {
     $this->assertTransmission(['target.txt' => 'Test'], $target);
   }


### PR DESCRIPTION
See https://github.com/xp-framework/rfc/issues/344 and https://github.com/xp-framework/test. Migration includes first converting all tests to no longer extend the `unittest.TestCase` class, then converting them to the new test library subsequently.

## Metrics
Before:
```bash
# src/test/php
Tests:       772 passed
Memory used: 7473.50 kB (7526.36 kB peak)
Time taken:  0.120 seconds

# src/it/php
Tests:       24 passed
Memory used: 2710.81 kB (2750.97 kB peak)
Time taken:  0.312 seconds
```

After:
```bash
# src/test/php
Test cases:  789 succeeded
Memory used: 6051.18 kB (6105.31 kB peak)
Time taken:  0.112 seconds (0.323 seconds overall)

# src/it/php
Test cases:  24 succeeded
Memory used: 2232.22 kB (2384.85 kB peak)
Time taken:  0.315 seconds (0.511 seconds overall)
```