### PR TITLE
Limit request size (status line and headers) to 16 K

### DIFF
--- a/src/test/php/web/unittest/HttpProtocolTest.class.php
+++ b/src/test/php/web/unittest/HttpProtocolTest.class.php
@@ -2,7 +2,7 @@
 
 use io\streams\Streams;
 use peer\SocketException;
-use test\{Assert, Test, Values};
+use test\{Assert, AssertionFailed, Test, Values};
 use web\{Application, Environment, Logging};
 use xp\web\srv\{CannotWrite, HttpProtocol};
 
@@ -37,7 +37,7 @@ class HttpProtocolTest {
   private function assertHttp($expected, $out) {
     $actual= implode('', $out);
     if (!preg_match('#^'.$expected.'$#', $actual)) {
-      $this->fail('=~', $actual, $expected);
+      throw new AssertionFailed($actual.' =~ '.$expected);
     }
   }
 

--- a/src/test/php/web/unittest/server/InputTest.class.php
+++ b/src/test/php/web/unittest/server/InputTest.class.php
@@ -1,11 +1,12 @@
 <?php namespace web\unittest\server;
 
 use io\streams\Streams;
-use peer\{Socket, SocketEndpoint};
+use peer\{Socket, SocketEndpoint, SocketTimeoutException};
 use test\{Assert, Test, Values};
 use xp\web\srv\Input;
 
 class InputTest {
+  const HEADER_LIMIT= 16384;
 
   /**
    * Returns a socket which can be read from
@@ -40,49 +41,81 @@ class InputTest {
     };
   }
 
+  /**
+   * Creates socket input and consumes status line and headers
+   *
+   * @param  peer.Socket $socket
+   * @return web.io.Input
+   */
+  private function consume($socket) {
+    $input= new Input($socket, false);
+
+    $c= $input->consume(self::HEADER_LIMIT);
+    while ($c->valid()) {
+      if ($socket->canRead()) {
+        $c->next();
+      } else {
+        $c->throw(new SocketTimeoutException('Timeout', 0.0));
+      }
+    }
+
+    return $input;
+  }
+
   #[Test]
   public function can_create() {
-    new Input($this->socket("GET / HTTP/1.1\r\n\r\n"));
+    $this->consume($this->socket("GET / HTTP/1.1\r\n\r\n"));
   }
 
   #[Test]
   public function close_kind() {
-    Assert::equals(Input::CLOSE, (new Input($this->socket('')))->kind);
+    Assert::equals(Input::CLOSE, ($this->consume($this->socket('')))->kind);
   }
 
   #[Test]
   public function request_kind() {
-    Assert::equals(Input::REQUEST, (new Input($this->socket("GET / HTTP/1.1\r\n\r\n")))->kind);
+    Assert::equals(Input::REQUEST, ($this->consume($this->socket("GET / HTTP/1.1\r\n\r\n")))->kind);
   }
 
   #[Test]
-  public function malformed_kind() {
-    Assert::equals('EHLO example.org', (new Input($this->socket("EHLO example.org\r\n")))->kind);
+  public function request_timeout() {
+    Assert::equals(Input::TIMEOUT, ($this->consume($this->socket("GET / HTTP/1.1\r\n...")))->kind);
+  }
+
+  #[Test]
+  public function incomplete_request() {
+    Assert::equals(Input::INCOMPLETE, ($this->consume($this->socket("EHLO example.org\r\n\r\n")))->kind);
+  }
+
+  #[Test]
+  public function header_limit_exceeded() {
+    $headers= 'Cookie: excess='.str_repeat('x', self::HEADER_LIMIT)."\r\n";
+    Assert::equals(Input::EXCESSIVE, ($this->consume($this->socket("GET / HTTP/1.1\r\n{$headers}\r\n")))->kind);
   }
 
   #[Test]
   public function http_scheme_default() {
-    Assert::equals('http', (new Input($this->socket("GET / HTTP/1.1\r\n\r\n")))->scheme());
+    Assert::equals('http', ($this->consume($this->socket("GET / HTTP/1.1\r\n\r\n")))->scheme());
   }
 
   #[Test]
   public function method() {
-    Assert::equals('GET', (new Input($this->socket("GET / HTTP/1.1\r\n\r\n")))->method());
+    Assert::equals('GET', ($this->consume($this->socket("GET / HTTP/1.1\r\n\r\n")))->method());
   }
 
   #[Test]
   public function uri() {
-    Assert::equals('/', (new Input($this->socket("GET / HTTP/1.1\r\n\r\n")))->uri());
+    Assert::equals('/', ($this->consume($this->socket("GET / HTTP/1.1\r\n\r\n")))->uri());
   }
 
   #[Test]
   public function version() {
-    Assert::equals('1.1', (new Input($this->socket("GET / HTTP/1.1\r\n\r\n")))->version());
+    Assert::equals('1.1', ($this->consume($this->socket("GET / HTTP/1.1\r\n\r\n")))->version());
   }
 
   #[Test]
   public function no_headers() {
-    $input= new Input($this->socket("GET / HTTP/1.1\r\n\r\n"));
+    $input= $this->consume($this->socket("GET / HTTP/1.1\r\n\r\n"));
     Assert::equals(
       ['Remote-Addr' => '127.0.0.1'],
       iterator_to_array($input->headers())
@@ -91,7 +124,7 @@ class InputTest {
 
   #[Test]
   public function headers() {
-    $input= new Input($this->socket("GET / HTTP/1.1\r\nHost: example\r\nDate: Tue, 15 Nov 1994 08:12:31 GMT\r\n\r\n"));
+    $input= $this->consume($this->socket("GET / HTTP/1.1\r\nHost: example\r\nDate: Tue, 15 Nov 1994 08:12:31 GMT\r\n\r\n"));
     Assert::equals(
       ['Remote-Addr' => '127.0.0.1', 'Host' => 'example', 'Date' => 'Tue, 15 Nov 1994 08:12:31 GMT'],
       iterator_to_array($input->headers())
@@ -100,7 +133,7 @@ class InputTest {
 
   #[Test]
   public function without_payload() {
-    $input= new Input($this->socket("GET / HTTP/1.1\r\n\r\n"));
+    $input= $this->consume($this->socket("GET / HTTP/1.1\r\n\r\n"));
     iterator_count($input->headers());
 
     Assert::null($input->incoming());
@@ -108,7 +141,7 @@ class InputTest {
 
   #[Test]
   public function with_content_length() {
-    $input= new Input($this->socket("POST / HTTP/1.1\r\nContent-Length: 4\r\n\r\nTest"));
+    $input= $this->consume($this->socket("POST / HTTP/1.1\r\nContent-Length: 4\r\n\r\nTest"));
     iterator_count($input->headers());
 
     Assert::equals('Test', Streams::readAll($input->incoming()));
@@ -116,7 +149,7 @@ class InputTest {
 
   #[Test]
   public function with_chunked_te() {
-    $input= new Input($this->socket("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nTest\r\n0\r\n\r\n"));
+    $input= $this->consume($this->socket("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nTest\r\n0\r\n\r\n"));
     iterator_count($input->headers());
 
     Assert::equals('Test', Streams::readAll($input->incoming()));
@@ -124,7 +157,7 @@ class InputTest {
 
   #[Test]
   public function read_length() {
-    $input= new Input($this->socket("POST / HTTP/1.1\r\nContent-Length: 4\r\n\r\nTest"));
+    $input= $this->consume($this->socket("POST / HTTP/1.1\r\nContent-Length: 4\r\n\r\nTest"));
     iterator_count($input->headers());
 
     Assert::equals('Test', $input->read(4));
@@ -132,7 +165,7 @@ class InputTest {
 
   #[Test]
   public function read_all() {
-    $input= new Input($this->socket("POST / HTTP/1.1\r\nContent-Length: 4\r\n\r\nTest"));
+    $input= $this->consume($this->socket("POST / HTTP/1.1\r\nContent-Length: 4\r\n\r\nTest"));
     iterator_count($input->headers());
 
     Assert::equals('Test', $input->read(-1));
@@ -141,7 +174,7 @@ class InputTest {
   #[Test, Values([1024, 4096, 8192])]
   public function with_large_headers($length) {
     $header= 'cookie='.str_repeat('*', $length);
-    $input= new Input($this->socket("GET / HTTP/1.1\r\nCookie: {$header}\r\n\r\n"));
+    $input= $this->consume($this->socket("GET / HTTP/1.1\r\nCookie: {$header}\r\n\r\n"));
     $headers= iterator_to_array($input->headers());
 
     Assert::equals($header, $headers['Cookie']);


### PR DESCRIPTION
Implements #100 for the standalone web server. Also prevents slow clients from blocking rest of the server.