### PR TITLE
Make it possible to append trace data to the response which will appear in the log file

### DIFF
--- a/src/main/php/web/Logging.class.php
+++ b/src/main/php/web/Logging.class.php
@@ -62,11 +62,11 @@ class Logging {
    *
    * @param  web.Request $response
    * @param  web.Response $response
-   * @param  ?web.Error $error Optional error
+   * @param  [:var] $hints Optional hints
    * @return void
    */
-  public function log($request, $response, $error= null) {
-    $this->sink && $this->sink->log($request, $response, $error);
+  public function log($request, $response, $hints= []) {
+    $this->sink && $this->sink->log($request, $response, $hints);
   }
 
   /**

--- a/src/main/php/web/Response.class.php
+++ b/src/main/php/web/Response.class.php
@@ -17,6 +17,7 @@ class Response {
   private $message= 'OK';
   private $cookies= [];
   private $headers= [];
+  public $trace= [];
 
   /** @param web.io.Output $output */
   public function __construct($output= null) {
@@ -66,6 +67,17 @@ class Response {
     } else {
       $this->headers[$name]= [(string)$value];
     }
+  }
+
+  /**
+   * Adds a named value to the trace, which will show up in the log file
+   *
+   * @param  string $name
+   * @param  var $value
+   * @return void
+   */
+  public function trace($name, $value) {
+    $this->trace[$name]= $value;
   }
 
   /** @return int */

--- a/src/main/php/web/logging/Sink.class.php
+++ b/src/main/php/web/logging/Sink.class.php
@@ -14,10 +14,10 @@ abstract class Sink {
    *
    * @param  web.Request $response
    * @param  web.Response $response
-   * @param  ?web.Error $error Optional error
+   * @param  [:var] $hints Optional hints
    * @return void
    */
-  public abstract function log($request, $response, $error);
+  public abstract function log($request, $response, $hints);
 
   /** @return string */
   public function target() { return nameof($this); }

--- a/src/main/php/web/logging/ToAllOf.class.php
+++ b/src/main/php/web/logging/ToAllOf.class.php
@@ -42,12 +42,12 @@ class ToAllOf extends Sink {
    *
    * @param  web.Request $response
    * @param  web.Response $response
-   * @param  ?web.Error $error Optional error
+   * @param  [:var] $hints Optional hints
    * @return void
    */
-  public function log($request, $response, $error) {
+  public function log($request, $response, $hints) {
     foreach ($this->sinks as $sink) {
-      $sink->log($request, $response, $error);
+      $sink->log($request, $response, $hints);
     }
   }
 }

--- a/src/main/php/web/logging/ToCategory.class.php
+++ b/src/main/php/web/logging/ToCategory.class.php
@@ -16,15 +16,15 @@ class ToCategory extends Sink {
    *
    * @param  web.Request $response
    * @param  web.Response $response
-   * @param  ?web.Error $error Optional error
+   * @param  [:var] $hints Optional hints
    * @return void
    */
-  public function log($request, $response, $error) {
+  public function log($request, $response, $hints) {
     $query= $request->uri()->query();
     $uri= $request->uri()->path().($query ? '?'.$query : '');
 
-    if ($error) {
-      $this->cat->warn($response->status(), $request->method(), $uri, $error);
+    if ($hints) {
+      $this->cat->warn($response->status(), $request->method(), $uri, $hints);
     } else {
       $this->cat->info($response->status(), $request->method(), $uri);
     }

--- a/src/main/php/web/logging/ToConsole.class.php
+++ b/src/main/php/web/logging/ToConsole.class.php
@@ -1,5 +1,6 @@
 <?php namespace web\logging;
 
+use util\Objects;
 use util\cmd\Console;
 
 class ToConsole extends Sink {
@@ -9,20 +10,25 @@ class ToConsole extends Sink {
    *
    * @param  web.Request $response
    * @param  web.Response $response
-   * @param  ?web.Error $error Optional error
+   * @param  [:var] $hints Optional hints
    * @return void
    */
-  public function log($request, $response, $error) {
+  public function log($request, $response, $hints) {
     $query= $request->uri()->query();
+    $hint= '';
+    foreach ($hints as $kind => $value) {
+      $hint.= ', '.$kind.': '.Objects::stringOf($value);
+    }
+
     Console::writeLinef(
-      "  \e[33m[%s %d %.3fkB]\e[0m %d %s %s %s",
+      "  \e[33m[%s %d %.3fkB]\e[0m %d %s %s%s",
       date('Y-m-d H:i:s'),
       getmypid(),
       memory_get_usage() / 1024,
       $response->status(),
       $request->method(),
       $request->uri()->path().($query ? '?'.$query : ''),
-      $error ? $error->toString() : ''
+      $hint ? " \e[3m[".substr($hint, 2)."]\e[0m" : ''
     );
   }
 }

--- a/src/main/php/web/logging/ToConsole.class.php
+++ b/src/main/php/web/logging/ToConsole.class.php
@@ -17,7 +17,7 @@ class ToConsole extends Sink {
     $query= $request->uri()->query();
     $hint= '';
     foreach ($hints as $kind => $value) {
-      $hint.= ', '.$kind.': '.Objects::stringOf($value);
+      $hint.= ', '.$kind.': '.(is_string($value) ? $value : Objects::stringOf($value));
     }
 
     Console::writeLinef(
@@ -28,7 +28,7 @@ class ToConsole extends Sink {
       $response->status(),
       $request->method(),
       $request->uri()->path().($query ? '?'.$query : ''),
-      $hint ? " \e[3m[".substr($hint, 2)."]\e[0m" : ''
+      $hint ? " \e[2m[".substr($hint, 2)."]\e[0m" : ''
     );
   }
 }

--- a/src/main/php/web/logging/ToFile.class.php
+++ b/src/main/php/web/logging/ToFile.class.php
@@ -37,18 +37,18 @@ class ToFile extends Sink {
     $query= $request->uri()->query();
     $hint= '';
     foreach ($hints as $kind => $value) {
-      $hint.= ', '.$kind.': '.Objects::stringOf($value);
+      $hint.= ', '.$kind.': '.(is_string($value) ? $value : Objects::stringOf($value));
     }
 
     $line= sprintf(
-      "[%s %d %.3fkB] %d %s %s %s\n",
+      "[%s %d %.3fkB] %d %s %s%s\n",
       date('Y-m-d H:i:s'),
       getmypid(),
       memory_get_usage() / 1024,
       $response->status(),
       $request->method(),
       $request->uri()->path().($query ? '?'.$query : ''),
-      $hint ? '['.substr($hint, 2).']' : ''
+      $hint ? ' ['.substr($hint, 2).']' : ''
     );
     file_put_contents($this->file, $line, FILE_APPEND | LOCK_EX);
   }

--- a/src/main/php/web/logging/ToFile.class.php
+++ b/src/main/php/web/logging/ToFile.class.php
@@ -2,6 +2,7 @@
 
 use io\File;
 use lang\IllegalArgumentException;
+use util\Objects;
 
 /**
  * Logfile sink writing to a file
@@ -29,11 +30,16 @@ class ToFile extends Sink {
    *
    * @param  web.Request $response
    * @param  web.Response $response
-   * @param  ?web.Error $error Optional error
+   * @param  [:var] $hints Optional hints
    * @return void
    */
-  public function log($request, $response, $error) {
+  public function log($request, $response, $hints) {
     $query= $request->uri()->query();
+    $hint= '';
+    foreach ($hints as $kind => $value) {
+      $hint.= ', '.$kind.': '.Objects::stringOf($value);
+    }
+
     $line= sprintf(
       "[%s %d %.3fkB] %d %s %s %s\n",
       date('Y-m-d H:i:s'),
@@ -42,7 +48,7 @@ class ToFile extends Sink {
       $response->status(),
       $request->method(),
       $request->uri()->path().($query ? '?'.$query : ''),
-      $error ? $error->toString() : ''
+      $hint ? '['.substr($hint, 2).']' : ''
     );
     file_put_contents($this->file, $line, FILE_APPEND | LOCK_EX);
   }

--- a/src/main/php/web/logging/ToFunction.class.php
+++ b/src/main/php/web/logging/ToFunction.class.php
@@ -5,7 +5,7 @@ class ToFunction extends Sink {
 
   /** @param callable $function */
   public function __construct($function) {
-    $this->function= cast($function, 'function(web.Request, web.Response, ?web.Error): void');
+    $this->function= cast($function, 'function(web.Request, web.Response, [:var]): void');
   }
 
   /**
@@ -13,10 +13,10 @@ class ToFunction extends Sink {
    *
    * @param  web.Request $response
    * @param  web.Response $response
-   * @param  ?web.Error $error Optional error
+   * @param  [:var] $hints Optional hints
    * @return void
    */
-  public function log($request, $response, $error) {
-    $this->function->__invoke($request, $response, $error);
+  public function log($request, $response, $hints) {
+    $this->function->__invoke($request, $response, $hints);
   }
 }

--- a/src/main/php/xp/web/WebRunner.class.php
+++ b/src/main/php/xp/web/WebRunner.class.php
@@ -46,7 +46,7 @@ class WebRunner {
         break;
       }
     }
-    $env->logging()->log($request, $response, $error);
+    $env->logging()->log($request, $response, ['error' => $error]);
   }
 
   /**

--- a/src/main/php/xp/web/srv/CannotWrite.class.php
+++ b/src/main/php/xp/web/srv/CannotWrite.class.php
@@ -5,5 +5,5 @@ use io\IOException;
 class CannotWrite extends IOException {
 
   /** @return string */
-  public function toString(): string { return '// '.$this->message; }
+  public function toString(): string { return $this->message; }
 }

--- a/src/main/php/xp/web/srv/HttpProtocol.class.php
+++ b/src/main/php/xp/web/srv/HttpProtocol.class.php
@@ -154,7 +154,7 @@ class HttpProtocol implements ServerProtocol {
 
         $this->logging->log($request, $response, $response->trace);
       } catch (CannotWrite $e) {
-        $this->logging->log($request, $response, $response->trace + ['warning' => $e]);
+        $this->logging->log($request, $response, $response->trace + ['warn' => $e]);
       } catch (Error $e) {
         $this->sendError($request, $response, $e);
       } catch (Throwable $e) {

--- a/src/test/php/web/unittest/HttpProtocolTest.class.php
+++ b/src/test/php/web/unittest/HttpProtocolTest.class.php
@@ -146,16 +146,16 @@ class HttpProtocolTest {
   }
 
   #[Test]
-  public function catches_write_errors_and_logs_them() {
+  public function catches_write_errors_and_logs_them_as_warning() {
     $caught= null;
     $p= HttpProtocol::executing(
       $this->application(function($req, $res) {
         with ($res->stream(), function($s) {
           $s->write('Test');
           throw new CannotWrite('Test error', new SocketException('...'));
-         });
+        });
       }),
-      Logging::of(function($req, $res, $error= null) use(&$caught) { $caught= $error; })
+      Logging::of(function($req, $res, $hints) use(&$caught) { $caught= $hints['warning']; })
     );
 
     $this->assertHttp(
@@ -167,6 +167,20 @@ class HttpProtocolTest {
       $this->handle($p, ["GET / HTTP/1.1\r\n\r\n"])
     );
     Assert::instance(CannotWrite::class, $caught);
-    Assert::equals('// Test error', $caught->toString());
+    Assert::equals('Test error', $caught->toString());
+  }
+
+  #[Test]
+  public function response_trace_appears_in_log() {
+    $logged= null;
+    $p= HttpProtocol::executing(
+      $this->application(function($req, $res) {
+        $res->trace('request-time-ms', 1);
+      }),
+      Logging::of(function($req, $res, $hints) use(&$logged) { $logged= $hints; })
+    );
+
+    $this->handle($p, ["GET / HTTP/1.1\r\n\r\n"]);
+    Assert::equals(['request-time-ms' => 1], $logged);
   }
 }

--- a/src/test/php/web/unittest/HttpProtocolTest.class.php
+++ b/src/test/php/web/unittest/HttpProtocolTest.class.php
@@ -155,7 +155,7 @@ class HttpProtocolTest {
           throw new CannotWrite('Test error', new SocketException('...'));
         });
       }),
-      Logging::of(function($req, $res, $hints) use(&$caught) { $caught= $hints['warning']; })
+      Logging::of(function($req, $res, $hints) use(&$caught) { $caught= $hints['warn']; })
     );
 
     $this->assertHttp(

--- a/src/test/php/web/unittest/ResponseTest.class.php
+++ b/src/test/php/web/unittest/ResponseTest.class.php
@@ -138,6 +138,13 @@ class ResponseTest {
   }
 
   #[Test]
+  public function trace() {
+    $res= new Response(new TestOutput());
+    $res->trace('request-time-ms', 1);
+    Assert::equals(['request-time-ms' => 1], $res->trace);
+  }
+
+  #[Test]
   public function hint() {
     $res= new Response(new TestOutput());
     $res->hint(100, 'Continue');

--- a/src/test/php/web/unittest/logging/ToCategoryTest.class.php
+++ b/src/test/php/web/unittest/logging/ToCategoryTest.class.php
@@ -25,7 +25,7 @@ class ToCategoryTest {
     $res= new Response(new TestOutput());
 
     $buffered= new BufferedAppender();
-    (new ToCategory((new LogCategory('test'))->withAppender($buffered)))->log($req, $res, null);
+    (new ToCategory((new LogCategory('test'))->withAppender($buffered)))->log($req, $res, []);
 
     Assert::notEquals(0, strlen($buffered->getBuffer()));
   }
@@ -36,7 +36,11 @@ class ToCategoryTest {
     $res= new Response(new TestOutput());
 
     $buffered= new BufferedAppender();
-    (new ToCategory((new LogCategory('test'))->withAppender($buffered)))->log($req, $res, new Error(404, 'Test'));
+    (new ToCategory((new LogCategory('test'))->withAppender($buffered)))->log(
+      $req,
+      $res,
+      ['error' => new Error(404, 'Test')]
+    );
 
     Assert::notEquals(0, strlen($buffered->getBuffer()));
   }

--- a/src/test/php/web/unittest/logging/ToConsoleTest.class.php
+++ b/src/test/php/web/unittest/logging/ToConsoleTest.class.php
@@ -12,10 +12,10 @@ class ToConsoleTest {
   /** 
    * Log a message
    *
-   * @param  ?web.Error $error
+   * @param  [:var] $hints
    * @return string
    */
-  private function log($error) {
+  private function log($hints) {
     $req= new Request(new TestInput('GET', '/'));
     $res= new Response(new TestOutput());
 
@@ -24,7 +24,7 @@ class ToConsoleTest {
     Console::$out->redirect($memory);
 
     try {
-      (new ToConsole())->log($req, $res, $error);
+      (new ToConsole())->log($req, $res, $hints);
       return $memory->bytes();
     } finally {
       Console::$out->redirect($restore);
@@ -38,11 +38,11 @@ class ToConsoleTest {
 
   #[Test]
   public function log_without_error() {
-    Assert::notEquals(0, strlen($this->log(null)));
+    Assert::notEquals(0, strlen($this->log([])));
   }
 
   #[Test]
   public function log_with_error() {
-    Assert::notEquals(0, strlen($this->log(new Error(404, 'Test'))));
+    Assert::notEquals(0, strlen($this->log(['error' => new Error(404, 'Test')])));
   }
 }

--- a/src/test/php/web/unittest/logging/ToFileTest.class.php
+++ b/src/test/php/web/unittest/logging/ToFileTest.class.php
@@ -54,7 +54,7 @@ class ToFileTest {
     $req= new Request(new TestInput('GET', '/'));
     $res= new Response(new TestOutput());
 
-    (new ToFile($this->temp))->log($req, $res, null);
+    (new ToFile($this->temp))->log($req, $res, []);
 
     Assert::notEquals(0, $this->temp->size());
   }
@@ -64,7 +64,7 @@ class ToFileTest {
     $req= new Request(new TestInput('GET', '/'));
     $res= new Response(new TestOutput());
 
-    (new ToFile($this->temp))->log($req, $res, new Error(404, 'Test'));
+    (new ToFile($this->temp))->log($req, $res, ['error' => new Error(404, 'Test')]);
 
     Assert::notEquals(0, $this->temp->size());
   }


### PR DESCRIPTION
The following code inside a handler:

```php
function($req, $res) {
  $start= microtime(true);

  // Here comes the implementation  

  $duration= 1000 * (microtime(true) - $start);
  $res->trace('execution', number_format($duration, 2).'ms');
}
```

...will append the string `[execution: 123.45ms]` to the logfile. 

* [x] Refactor the logger signature from `(web.Request, web.Response, ?web.Error)` to `(web.Request, web.Response, [:var])`
* [x] Adapt all `web.logging.Sink` implementations
* [x] Add `Response::trace()`
* [x] Trace `CannotWrite` as a *warn*, other errors as *error*

See http://expressjs.com/en/resources/middleware/response-time.html