### PR TITLE
Make `xp web [name]` load the class xp.[name].Web

### DIFF
--- a/src/main/php/xp/web/Source.class.php
+++ b/src/main/php/xp/web/Source.class.php
@@ -24,7 +24,13 @@ class Source {
 
     $cl= ClassLoader::getDefault();
     try {
-      $class= is_file($application) ? $cl->loadUri($application) : $cl->loadClass($application);
+      if (is_file($application)) {
+        $class= $cl->loadUri($application);
+      } else if ($application[0] < 'a' || false !== strpos($application, '.')) {
+        $class= $cl->loadClass($application);
+      } else {
+        $class= $cl->loadClass("xp.{$application}.Web");
+      }
     } catch (ClassLoadingException $e) {
       throw new IllegalArgumentException('Cannot load class '.$application, $e);
     }

--- a/src/main/php/xp/web/Source.class.php
+++ b/src/main/php/xp/web/Source.class.php
@@ -32,11 +32,11 @@ class Source {
         $class= $cl->loadClass("xp.{$application}.Web");
       }
     } catch (ClassLoadingException $e) {
-      throw new IllegalArgumentException('Cannot load class '.$application, $e);
+      throw new IllegalArgumentException('Cannot load web application '.$application, $e);
     }
 
     if (!$class->isSubclassOf(Application::class)) {
-      throw new IllegalArgumentException($class->getName().' is not a web.Application');
+      throw new IllegalArgumentException($class->getName().' is not a web application');
     }
 
     return $class->newInstance($environment);

--- a/src/test/php/web/unittest/SourceTest.class.php
+++ b/src/test/php/web/unittest/SourceTest.class.php
@@ -48,12 +48,12 @@ class SourceTest {
     Assert::instance(HelloWorld::class, $src->application());
   }
 
-  #[Test, Expect(class: IllegalArgumentException::class, message: 'Cannot load class not.a.class')]
+  #[Test, Expect(class: IllegalArgumentException::class, message: 'Cannot load web application not.a.class')]
   public function non_existant_class() {
     (new Source('not.a.class', $this->environment))->application();
   }
 
-  #[Test, Expect(class: IllegalArgumentException::class, message: 'util.Date is not a web.Application')]
+  #[Test, Expect(class: IllegalArgumentException::class, message: 'util.Date is not a web application')]
   public function unrelated_class() {
     (new Source('util.Date', $this->environment))->application();
   }

--- a/src/test/php/web/unittest/SourceTest.class.php
+++ b/src/test/php/web/unittest/SourceTest.class.php
@@ -37,7 +37,7 @@ class SourceTest {
 
   #[Test]
   public function application_file() {
-    $base= ClassLoader::getDefault()->findClass(HelloWorld::class)->path;
+    $base= ClassLoader::getDefault()->findClass('web.unittest.HelloWorld')->path;
     $src= new Source(new Path($base, 'web/unittest/HelloWorld.class.php'), $this->environment);
     Assert::instance(HelloWorld::class, $src->application());
   }

--- a/src/test/php/web/unittest/SourceTest.class.php
+++ b/src/test/php/web/unittest/SourceTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace web\unittest;
 
 use io\Path;
-use lang\{XPClass, IllegalArgumentException, ClassLoader};
+use lang\{IllegalArgumentException, ClassLoader};
 use test\{Assert, Before, Expect, Test};
 use web\{Application, Environment};
 use xp\web\{ServeDocumentRootStatically, Source};


### PR DESCRIPTION
This PR makes it shorter to load specialized web applications by being able to refer to them with a lowercased version, e.g. `xp web lambda Greet` instead of `xp web xp.lambda.Ws Greet`. It saves only a couple of keystrikes but falls in line with xp-forge/web@7f3f773c99c3b256f53a46a9406e2db988d5fdb8, which aliased the command line option `-m dev` to `-m develop`.

## Example

```bash
$ xp web lambda Greet
@xp.web.srv.Standalone(HTTP @ peer.ServerSocket(Resource id #124 -> tcp://127.0.0.1:8080))
Serving prod:xp.lambda.Web<Greet>[] > web.logging.ToConsole
════════════════════════════════════════════════════════════════════════
> Server started: http://localhost:8080 in 0.057 seconds
  Sat, 18 Nov 2023 12:19:32 +0100 - PID 18668; press Ctrl+C to exit

# ...
```

See https://github.com/xp-forge/lambda-ws/pull/11#issuecomment-1819560872