### PR TITLE
Implement WriteChunks::flush() to use for explicitely flushing

### DIFF
--- a/src/main/php/web/io/WriteChunks.class.php
+++ b/src/main/php/web/io/WriteChunks.class.php
@@ -45,8 +45,18 @@ class WriteChunks extends Output {
   }
 
   /** @return void */
+  public function flush() {
+    if (strlen($this->buffer) > 0) {
+      $this->target->write(dechex(strlen($this->buffer))."\r\n".$this->buffer."\r\n");
+      $this->buffer= '';
+      $this->target->flush();
+    }
+  }
+
+  /** @return void */
   public function finish() {
-    $this->target->write(dechex(strlen($this->buffer))."\r\n".$this->buffer."\r\n0\r\n\r\n");
+    $this->flush();
+    $this->target->write("0\r\n\r\n");
     $this->target->close();
   }
 }

--- a/src/test/php/web/unittest/io/WriteChunksTest.class.php
+++ b/src/test/php/web/unittest/io/WriteChunksTest.class.php
@@ -46,4 +46,42 @@ class WriteChunksTest {
 
     Assert::equals("1001\r\n".$chunk."\r\n4\r\nTest\r\n0\r\n\r\n", $out->bytes());
   }
+
+  #[Test]
+  public function flush() {
+    $out= new TestOutput();
+
+    $w= new WriteChunks($out);
+    $w->flush();
+    $w->finish();
+
+    Assert::equals("0\r\n\r\n", $out->bytes());
+  }
+
+  #[Test]
+  public function write_then_explicitely_flush() {
+    $out= new TestOutput();
+
+    $w= new WriteChunks($out);
+    $w->write('Test');
+    $w->flush();
+    $w->finish();
+
+    Assert::equals("4\r\nTest\r\n0\r\n\r\n", $out->bytes());
+  }
+
+  #[Test]
+  public function no_data_written_until_flushed() {
+    $out= new TestOutput();
+
+    $w= new WriteChunks($out);
+    $w->write('Test');
+    $before= $out->bytes();
+    $w->flush();
+    $after= $out->bytes();
+    $w->finish();
+
+    Assert::equals('', $before);
+    Assert::equals("4\r\nTest\r\n", $after);
+  }
 }


### PR DESCRIPTION
Can be used to implement [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events):

```php
function($req, $res) {
  $res->header('Content-Type', 'text/event-stream');
  $res->header('Cache-Control', 'no-store');

  $stream= $res->stream();
  $i= 1;
  do {
    $stream->write("event: message\n");
    $stream->write("data: Message {$i}\n\n");
    $stream->flush();  // Otherwise, will not send any data until 4096 bytes have been buffered

    yield 'sleep' => 1000;
  } while ($i++ < 10);

  $stream->close();
}
```

**Note**: This technique does not work inside the development webserver because it cannot serve requests while a handler is running, and does not support pausing and resuming handlers with `yield`!