### PR TITLE
Make it possible to pass a function to be run prior to flushing the response

### DIFF
--- a/src/main/php/web/Response.class.php
+++ b/src/main/php/web/Response.class.php
@@ -12,6 +12,7 @@ use web\io\WriteChunks;
  */
 class Response {
   private $output;
+  private $flushing= null;
   private $flushed= false;
   private $status= 200;
   private $message= 'OK';
@@ -111,11 +112,23 @@ class Response {
 
   /** @param web.io.Output $output */
   private function begin($output) {
+    $this->flushing && ($this->flushing)($this);
     $output->begin($this->status, $this->message, $this->cookies
       ? array_merge($this->headers, ['Set-Cookie' => array_map(function($c) { return $c->header(); }, $this->cookies)])
       : $this->headers
     );
     $this->flushed= true;
+  }
+
+  /**
+   * Passes a function to call before flushing the response
+   *
+   * @param  ?function(self): void $function
+   * @return self
+   */
+  public function flushing($function) {
+    $this->flushing= $function;
+    return $this;
   }
 
   /**

--- a/src/test/php/web/unittest/ResponseTest.class.php
+++ b/src/test/php/web/unittest/ResponseTest.class.php
@@ -315,4 +315,24 @@ class ResponseTest {
     $res->flush();
     $res->flush();
   }
+
+  #[Test]
+  public function flushing_explicitely() {
+    $executed= 0;
+    $res= (new Response(new TestOutput()))->flushing(function() use(&$executed) {
+      $executed++;
+    });
+    $res->flush();
+    Assert::equals(1, $executed);
+  }
+
+  #[Test]
+  public function flushing_implicitely() {
+    $executed= 0;
+    $res= (new Response(new TestOutput()))->flushing(function() use(&$executed) {
+      $executed++;
+    });
+    $res->send('Test', 'text/plain');
+    Assert::equals(1, $executed);
+  }
 }


### PR DESCRIPTION
This makes it easy to implement [Server timing](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/Server_timing), which appears in the browser's developer console, as follows:

```php
class WithServerTiming implements Filter {

  public function filter($req, $res, $invocation) {
    $start= microtime(true);
    $res->flushing(function($res) use($start) {
      $res->header('Server-Timing', sprintf('total;dur=%.3f', 1000 * (microtime(true) - $start)));
    });

    return $invocation->proceed($req, $res);
  }
}
```

Ideally, we would do this via HTTP trailers which can be appended to the response, but this only works in Firefox, see https://bugzilla.mozilla.org/show_bug.cgi?id=1413999 and https://www.fastly.com/blog/supercharging-server-timing-http-trailers/, so we need a way to append this information at the last moment possible: before finishing sending the headers.