### PR TITLE
Add Headers::qfactors() to implement content negotiation

### DIFF
--- a/src/main/php/web/Headers.class.php
+++ b/src/main/php/web/Headers.class.php
@@ -96,13 +96,13 @@ abstract class Headers {
   }
 
   /**
-   * Returns a new parser for qvalues headers, e.g.:
+   * Returns a new parser for quality-factor headers, e.g.:
    *
    * `Accept-Encoding: deflate, gzip;q=1.0, *;q=0.5`
    *
    * @return self
    */
-  public static function qvalues() {
+  public static function qfactors() {
     return new class() extends Headers {
       protected function next($input, &$offset) {
         $weighted= [];

--- a/src/main/php/web/Headers.class.php
+++ b/src/main/php/web/Headers.class.php
@@ -8,7 +8,7 @@ use util\Date;
  *
  * @see   https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
  * @see   https://en.wikipedia.org/wiki/Content_negotiation
- * @test  xp://web.unittest.HeadersTest
+ * @test  web.unittest.HeadersTest
  */
 abstract class Headers {
 

--- a/src/main/php/web/Headers.class.php
+++ b/src/main/php/web/Headers.class.php
@@ -123,7 +123,7 @@ abstract class Headers {
           $q-= 0.0001;
         } while ($c);
 
-        arsort($weighted);
+        arsort($weighted, SORT_NUMERIC);
         return $weighted;
       }
     };

--- a/src/test/php/web/unittest/HeadersTest.class.php
+++ b/src/test/php/web/unittest/HeadersTest.class.php
@@ -46,7 +46,7 @@ class HeadersTest {
   public function accept() {
     Assert::equals(
       ['text/html' => 1.0, 'application/json' => 0.9, '*/*' => 0.8],
-      Headers::qvalues()->parse('text/html, application/json;q=0.9, */*;q=0.8')
+      Headers::qfactors()->parse('text/html, application/json;q=0.9, */*;q=0.8')
     );
   }
 
@@ -54,7 +54,7 @@ class HeadersTest {
   public function accept_encoding() {
     Assert::equals(
       ['deflate' => 1.0, 'gzip' => 1.0, '*' => 0.5],
-      Headers::qvalues()->parse('deflate, gzip;q=1.0, *;q=0.5')
+      Headers::qfactors()->parse('deflate, gzip;q=1.0, *;q=0.5')
     );
   }
 

--- a/src/test/php/web/unittest/HeadersTest.class.php
+++ b/src/test/php/web/unittest/HeadersTest.class.php
@@ -45,12 +45,16 @@ class HeadersTest {
   #[Test]
   public function accept() {
     Assert::equals(
-      [
-        new Parameterized('text/html', []),
-        new Parameterized('application/json', ['q' => '0.9']),
-        new Parameterized('*/*', ['q' => '0.8']),
-      ],
-      Headers::values(Headers::parameterized())->parse('text/html, application/json;q=0.9, */*;q=0.8')
+      ['text/html' => 1.0, 'application/json' => 0.9, '*/*' => 0.8],
+      Headers::qvalues()->parse('text/html, application/json;q=0.9, */*;q=0.8')
+    );
+  }
+
+  #[Test]
+  public function accept_encoding() {
+    Assert::equals(
+      ['deflate' => 1.0, 'gzip' => 1.0, '*' => 0.5],
+      Headers::qvalues()->parse('deflate, gzip;q=1.0, *;q=0.5')
     );
   }
 


### PR DESCRIPTION
Example:

```php
$preference= Headers::qfactors()->parse('deflate, gzip;q=1.0, *;q=0.5');
// ['deflate' => 1.0, 'gzip' => 1.0, '*' => 0.5]
```

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation