### PR TITLE
Catch errors and display in development console

### DIFF
--- a/src/main/php/web/error-prod.html
+++ b/src/main/php/web/error-prod.html
@@ -1,23 +1,29 @@
 <!DOCTYPE html>
-<html>
-  <head>
-    <title>Error %1$d [%2$s]</title>
-    <style type="text/css">
-      body { font-family: "Segoe UI",Arial,Helvetica; }
-      #content { margin: 2em; }
-      h1 image { float: left; margin-right: 0.5em; }
-      h1 #code { padding: 0.1em 0.5em; background-color: #cc0000; color: white; border-radius: 0.1em; }
-    </style>
-  </head>
-  <body bgcolor="#ffffff" text="#000000">
-    <div id="content">
-      <h1>
-        <img width="59" height="48" src="data:image/gif;base64,R0lGODlhOwAwAJEAAP///8wAAAAAAAAAACwAAAAAOwAwAAAC/ISPqWvBD6OctNrl7nUc9O+FWTJqmKmUiIqibMu8sAzPYR3jq8iDPhUICofEjq5BShWXweQR0oxEaaYSKwq9Ph9YbmbEZHJ3JGrjGi62mmnPt/qyKt3i7g1ojlmFK+M5PRVH1idhBzh0Blfod8exlJgyeGCHocLG9+imKMUIRkcE6YRU5qXZd/iVV1k6NYkaKom2WPZqupHX+gcIOynJS2iImrq5mis8HNlLykl7+DtBOSdy/Cy3nHVaG70ofHd7opztHI63Bf7ZnUM+c7xtTuU+5usijfNzz+MqVqEKt28O5B1ARgA19LNwUJ0TfAy9PUlYMGDEiRQrWqxYAAA7" alt="Error"/>
+<html lang="en">
+<head>
+  <title>Error %1$d [%2$s]</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Error message">
+  <style type="text/css">
+    body    { font-family: system-ui,Arial,Helvetica; }
+    main    { margin: 2rem 1rem; }
+    h1      { display: flex; align-items: center; border-radius: .25rem; width: fit-content; background-color: rgb(204, 0, 0); color: white; }
+    h1 svg  { margin-left: 1rem; }
+    #code   { margin: .25rem 1rem; text-transform: uppercase; }
+    #detail { font-size: 1.05rem; }
+  </style>
+</head>
+<body bgcolor="#ffffff" text="#000000">
+  <main>
+    <h1>
+      <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-patch-exclamation" viewBox="0 0 16 16">
+        <path d="M7.001 11a1 1 0 1 1 2 0 1 1 0 0 1-2 0M7.1 4.995a.905.905 0 1 1 1.8 0l-.35 3.507a.553.553 0 0 1-1.1 0z"/>
+        <path d="m10.273 2.513-.921-.944.715-.698.622.637.89-.011a2.89 2.89 0 0 1 2.924 2.924l-.01.89.636.622a2.89 2.89 0 0 1 0 4.134l-.637.622.011.89a2.89 2.89 0 0 1-2.924 2.924l-.89-.01-.622.636a2.89 2.89 0 0 1-4.134 0l-.622-.637-.89.011a2.89 2.89 0 0 1-2.924-2.924l.01-.89-.636-.622a2.89 2.89 0 0 1 0-4.134l.637-.622-.011-.89a2.89 2.89 0 0 1 2.924-2.924l.89.01.622-.636a2.89 2.89 0 0 1 4.134 0l-.715.698a1.89 1.89 0 0 0-2.704 0l-.92.944-1.32-.016a1.89 1.89 0 0 0-1.911 1.912l.016 1.318-.944.921a1.89 1.89 0 0 0 0 2.704l.944.92-.016 1.32a1.89 1.89 0 0 0 1.912 1.911l1.318-.016.921.944a1.89 1.89 0 0 0 2.704 0l.92-.944 1.32.016a1.89 1.89 0 0 0 1.911-1.912l-.016-1.318.944-.921a1.89 1.89 0 0 0 0-2.704l-.944-.92.016-1.32a1.89 1.89 0 0 0-1.912-1.911z"/>
+      </svg>
 
-        <span id="code">ERROR %1$d</span>
-        <span id="message">%2$s</span>
-      </h1>
-      <p id="detail">%3$s</p>
-    </div>
-  </body>
+      <span id="code">Error %1$d</span>
+    </h1>
+    <p id="detail"><b>%2$s</b>: %3$s</p>
+  </main>
+</body>
 </html>

--- a/src/main/php/web/error.html
+++ b/src/main/php/web/error.html
@@ -1,24 +1,31 @@
 <!DOCTYPE html>
-<html>
-  <head>
-    <title>Error %1$d [%2$s]</title>
-    <style type="text/css">
-      body { font-family: "Segoe UI",Arial,Helvetica; }
-      #content { margin: 2em; }
-      h1 image { float: left; margin-right: 0.5em; }
-      h1 #code { padding: 0.1em 0.5em; background-color: #cc0000; color: white; border-radius: 0.1em; }
-    </style>
-  </head>
-  <body bgcolor="#ffffff" text="#000000">
-    <div id="content">
-      <h1>
-        <img width="59" height="48" src="data:image/gif;base64,R0lGODlhOwAwAJEAAP///8wAAAAAAAAAACwAAAAAOwAwAAAC/ISPqWvBD6OctNrl7nUc9O+FWTJqmKmUiIqibMu8sAzPYR3jq8iDPhUICofEjq5BShWXweQR0oxEaaYSKwq9Ph9YbmbEZHJ3JGrjGi62mmnPt/qyKt3i7g1ojlmFK+M5PRVH1idhBzh0Blfod8exlJgyeGCHocLG9+imKMUIRkcE6YRU5qXZd/iVV1k6NYkaKom2WPZqupHX+gcIOynJS2iImrq5mis8HNlLykl7+DtBOSdy/Cy3nHVaG70ofHd7opztHI63Bf7ZnUM+c7xtTuU+5usijfNzz+MqVqEKt28O5B1ARgA19LNwUJ0TfAy9PUlYMGDEiRQrWqxYAAA7" alt="Error"/>
+<html lang="en">
+<head>
+  <title>Error %1$d [%2$s]</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Error message">
+  <style type="text/css">
+    body    { font-family: system-ui,Arial,Helvetica; }
+    main    { margin: 2rem 1rem; }
+    h1      { display: flex; align-items: center; border-radius: .25rem; width: fit-content; background-color: rgb(204, 0, 0); color: white; }
+    h1 svg  { margin-left: 1rem; }
+    #code   { margin: .25rem 1rem; text-transform: uppercase; }
+    #detail { font-size: 1.05rem; }
+    #trace  { background-color: rgb(240, 240, 240); border-radius: .25rem; overflow: hidden; padding: .5rem; font-size: .925rem; }
+  </style>
+</head>
+<body bgcolor="#ffffff" text="#000000">
+  <main>
+    <h1>
+      <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-patch-exclamation" viewBox="0 0 16 16">
+        <path d="M7.001 11a1 1 0 1 1 2 0 1 1 0 0 1-2 0M7.1 4.995a.905.905 0 1 1 1.8 0l-.35 3.507a.553.553 0 0 1-1.1 0z"/>
+        <path d="m10.273 2.513-.921-.944.715-.698.622.637.89-.011a2.89 2.89 0 0 1 2.924 2.924l-.01.89.636.622a2.89 2.89 0 0 1 0 4.134l-.637.622.011.89a2.89 2.89 0 0 1-2.924 2.924l-.89-.01-.622.636a2.89 2.89 0 0 1-4.134 0l-.622-.637-.89.011a2.89 2.89 0 0 1-2.924-2.924l.01-.89-.636-.622a2.89 2.89 0 0 1 0-4.134l.637-.622-.011-.89a2.89 2.89 0 0 1 2.924-2.924l.89.01.622-.636a2.89 2.89 0 0 1 4.134 0l-.715.698a1.89 1.89 0 0 0-2.704 0l-.92.944-1.32-.016a1.89 1.89 0 0 0-1.911 1.912l.016 1.318-.944.921a1.89 1.89 0 0 0 0 2.704l.944.92-.016 1.32a1.89 1.89 0 0 0 1.912 1.911l1.318-.016.921.944a1.89 1.89 0 0 0 2.704 0l.92-.944 1.32.016a1.89 1.89 0 0 0 1.911-1.912l-.016-1.318.944-.921a1.89 1.89 0 0 0 0-2.704l-.944-.92.016-1.32a1.89 1.89 0 0 0-1.912-1.911z"/>
+      </svg>
 
-        <span id="code">ERROR %1$d</span>
-        <span id="message">%2$s</span>
-      </h1>
-      <p id="detail">%3$s</p>
-      <pre id="trace">%4$s</pre>
-    </div>
-  </body>
+      <span id="code">Error %1$d</span>
+    </h1>
+    <p id="detail"><b>%2$s</b>: %3$s</p>
+    <pre id="trace">%4$s</pre>
+  </main>
+</body>
 </html>

--- a/src/main/php/xp/web/dev/Console.class.php
+++ b/src/main/php/xp/web/dev/Console.class.php
@@ -2,7 +2,7 @@
 
 use Closure, Throwable;
 use lang\XPException;
-use web\{Filter, Response};
+use web\{Filter, Response, Error};
 
 /**
  * The development console captures content written via `var_dump()`,
@@ -56,6 +56,7 @@ class Console implements Filter {
       $debug= ob_get_clean();
     } catch (Throwable $t) {
       $kind= 'error';
+      $buffer->answer($t instanceof Error ? $t->status() : 500);
       $debug= ob_get_clean()."\n".XPException::wrap($t)->toString();
     } finally {
       $buffer->end();

--- a/src/main/php/xp/web/dev/console.html
+++ b/src/main/php/xp/web/dev/console.html
@@ -1,81 +1,81 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <title>Console: {{kind}}</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Developer console">
-    <style type="text/css">
-      body         { font-family: system-ui,Arial,Helvetica; background-color: rgb(33, 37, 41); color: rgb(205, 211, 222); }
-      .debug       { background-color: rgb(102, 153, 204); }
-      .error       { background-color: rgb(204, 0, 0); }
-      main         { margin: 2rem 1rem; }
-      h1           { display: flex; align-items: center; color: white; border-radius: .25rem; width: fit-content; }
-      h1 svg       { margin-left: 1rem; }
-      #code        { margin: .25rem 1rem; text-transform: uppercase; }
-      #debug       { background-color: rgb(27, 43, 52); border-radius: .25rem; overflow: hidden; padding: .5rem; font-size: .925rem; }
-      #status      { color: rgb(102, 153, 204); }
-      button.clip  { float: right; }
-      table        { margin-bottom: 1.5rem; }
-      td           { padding: .25rem; }
-      td.name      { background-color: rgb(27, 43, 52); }
-      td.value     { color: rgb(249, 145, 87); font-family: monospace; font-size: .925rem; }
-      button       { background-color: rgb(61, 76, 85); color: white; cursor: pointer; padding: .25rem .5rem; border-radius: .15rem; border: none; }
-      button:hover { background-color: rgb(102, 153, 204); transition: all 150ms; }
-    </style>
-  </head>
-  <body bgcolor="#ffffff" text="#000000">
-    <main>
-      <!-- Debug output -->
-      <h1 class="{{kind}}">
-        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-bug" viewBox="0 0 16 16">
-          <path d="M4.355.522a.5.5 0 0 1 .623.333l.291.956A5 5 0 0 1 8 1c1.007 0 1.946.298 2.731.811l.29-.956a.5.5 0 1 1 .957.29l-.41 1.352A5 5 0 0 1 13 6h.5a.5.5 0 0 0 .5-.5V5a.5.5 0 0 1 1 0v.5A1.5 1.5 0 0 1 13.5 7H13v1h1.5a.5.5 0 0 1 0 1H13v1h.5a1.5 1.5 0 0 1 1.5 1.5v.5a.5.5 0 1 1-1 0v-.5a.5.5 0 0 0-.5-.5H13a5 5 0 0 1-10 0h-.5a.5.5 0 0 0-.5.5v.5a.5.5 0 1 1-1 0v-.5A1.5 1.5 0 0 1 2.5 10H3V9H1.5a.5.5 0 0 1 0-1H3V7h-.5A1.5 1.5 0 0 1 1 5.5V5a.5.5 0 0 1 1 0v.5a.5.5 0 0 0 .5.5H3c0-1.364.547-2.601 1.432-3.503l-.41-1.352a.5.5 0 0 1 .333-.623M4 7v4a4 4 0 0 0 3.5 3.97V7zm4.5 0v7.97A4 4 0 0 0 12 11V7zM12 6a4 4 0 0 0-1.334-2.982A3.98 3.98 0 0 0 8 2a3.98 3.98 0 0 0-2.667 1.018A4 4 0 0 0 4 6z"/>
+<head>
+  <title>Console: {{kind}}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Developer console">
+  <style type="text/css">
+    body         { font-family: system-ui,Arial,Helvetica; background-color: rgb(33, 37, 41); color: rgb(205, 211, 222); }
+    .debug       { background-color: rgb(102, 153, 204); }
+    .error       { background-color: rgb(204, 0, 0); }
+    main         { margin: 2rem 1rem; }
+    h1           { display: flex; align-items: center; color: white; border-radius: .25rem; width: fit-content; }
+    h1 svg       { margin-left: 1rem; }
+    #code        { margin: .25rem 1rem; text-transform: uppercase; }
+    #debug       { background-color: rgb(27, 43, 52); border-radius: .25rem; overflow: hidden; padding: .5rem; font-size: .925rem; }
+    #status      { color: rgb(102, 153, 204); }
+    button.clip  { float: right; }
+    table        { margin-bottom: 1.5rem; }
+    td           { padding: .25rem; }
+    td.name      { background-color: rgb(27, 43, 52); }
+    td.value     { color: rgb(249, 145, 87); font-family: monospace; font-size: .925rem; }
+    button       { background-color: rgb(61, 76, 85); color: white; cursor: pointer; padding: .25rem .5rem; border-radius: .15rem; border: none; }
+    button:hover { background-color: rgb(102, 153, 204); transition: all 150ms; }
+  </style>
+</head>
+<body bgcolor="#ffffff" text="#000000">
+  <main>
+    <!-- Debug output -->
+    <h1 class="{{kind}}">
+      <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-bug" viewBox="0 0 16 16">
+        <path d="M4.355.522a.5.5 0 0 1 .623.333l.291.956A5 5 0 0 1 8 1c1.007 0 1.946.298 2.731.811l.29-.956a.5.5 0 1 1 .957.29l-.41 1.352A5 5 0 0 1 13 6h.5a.5.5 0 0 0 .5-.5V5a.5.5 0 0 1 1 0v.5A1.5 1.5 0 0 1 13.5 7H13v1h1.5a.5.5 0 0 1 0 1H13v1h.5a1.5 1.5 0 0 1 1.5 1.5v.5a.5.5 0 1 1-1 0v-.5a.5.5 0 0 0-.5-.5H13a5 5 0 0 1-10 0h-.5a.5.5 0 0 0-.5.5v.5a.5.5 0 1 1-1 0v-.5A1.5 1.5 0 0 1 2.5 10H3V9H1.5a.5.5 0 0 1 0-1H3V7h-.5A1.5 1.5 0 0 1 1 5.5V5a.5.5 0 0 1 1 0v.5a.5.5 0 0 0 .5.5H3c0-1.364.547-2.601 1.432-3.503l-.41-1.352a.5.5 0 0 1 .333-.623M4 7v4a4 4 0 0 0 3.5 3.97V7zm4.5 0v7.97A4 4 0 0 0 12 11V7zM12 6a4 4 0 0 0-1.334-2.982A3.98 3.98 0 0 0 8 2a3.98 3.98 0 0 0-2.667 1.018A4 4 0 0 0 4 6z"/>
+      </svg>
+      <span id="code">{{kind}}</span>
+    </h1>
+    <div id="debug">
+      <button class="clip" title="Copy to clipboard" onclick="clip(document.getElementById('output').innerText); flash(document.getElementById('debug'))">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-clipboard-plus" viewBox="0 0 16 16">
+          <path fill-rule="evenodd" d="M8 7a.5.5 0 0 1 .5.5V9H10a.5.5 0 0 1 0 1H8.5v1.5a.5.5 0 0 1-1 0V10H6a.5.5 0 0 1 0-1h1.5V7.5A.5.5 0 0 1 8 7"/>
+          <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1z"/>
+          <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0z"/>
         </svg>
-        <span id="code">{{kind}}</span>
-      </h1>
-      <div id="debug">
-        <button class="clip" title="Copy to clipboard" onclick="clip(document.getElementById('output').innerText); flash(document.getElementById('debug'))">
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-clipboard-plus" viewBox="0 0 16 16">
-            <path fill-rule="evenodd" d="M8 7a.5.5 0 0 1 .5.5V9H10a.5.5 0 0 1 0 1H8.5v1.5a.5.5 0 0 1-1 0V10H6a.5.5 0 0 1 0-1h1.5V7.5A.5.5 0 0 1 8 7"/>
-            <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1z"/>
-            <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0z"/>
-          </svg>
-        </button>
-        <pre id="output">{{debug}}</pre>
-      </div>
+      </button>
+      <pre id="output">{{debug}}</pre>
+    </div>
 
-      <!-- Original HTTP response -->
-      <h2>HTTP/1.1 <span id="status">{{status}} {{message}}</span></h2>
-      <table id="headers">
-        {{#rows headers}}
-      </table>
-      <pre id="body">{{contents}}</pre>
-    </main>
-    <script type="text/javascript">
-      function clip(text) {
-        if (window.clipboardData) {
-          window.clipboardData.setData('Text', text);
-        } else {
-          var t = document.createElement('textarea');
-          t.value = text;
-          t.style.position = 'fixed';
-          t.style.top = 0;
-          t.style.left = 0;
-          t.style.width = '2em';
-          t.style.height = '2em';
-          t.style.background = 'transparent';
-          t.style.border = 'none';
-          document.body.appendChild(t);
-          t.select();
-          document.execCommand('copy');
-          document.body.removeChild(t);
-        }
+    <!-- Original HTTP response -->
+    <h2>HTTP/1.1 <span id="status">{{status}} {{message}}</span></h2>
+    <table id="headers">
+      {{#rows headers}}
+    </table>
+    <pre id="body">{{contents}}</pre>
+  </main>
+  <script type="text/javascript">
+    function clip(text) {
+      if (window.clipboardData) {
+        window.clipboardData.setData('Text', text);
+      } else {
+        var t = document.createElement('textarea');
+        t.value = text;
+        t.style.position = 'fixed';
+        t.style.top = 0;
+        t.style.left = 0;
+        t.style.width = '2em';
+        t.style.height = '2em';
+        t.style.background = 'transparent';
+        t.style.border = 'none';
+        document.body.appendChild(t);
+        t.select();
+        document.execCommand('copy');
+        document.body.removeChild(t);
       }
+    }
 
-      function flash(div) {
-        div.style.transition = 'all 200ms linear';
-        div.style.backgroundColor = 'rgb(61, 76, 85)';
-        setTimeout(function() { div.style.backgroundColor = null; }, 200);
-      }
-    </script>
-  </body>
+    function flash(div) {
+      div.style.transition = 'all 200ms linear';
+      div.style.backgroundColor = 'rgb(61, 76, 85)';
+      setTimeout(function() { div.style.backgroundColor = null; }, 200);
+    }
+  </script>
+</body>
 </html>

--- a/src/main/php/xp/web/dev/console.html
+++ b/src/main/php/xp/web/dev/console.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Console: {{kind}}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Developer console">
     <style type="text/css">
       body         { font-family: system-ui,Arial,Helvetica; background-color: rgb(33, 37, 41); color: rgb(205, 211, 222); }
       .debug       { background-color: rgb(102, 153, 204); }

--- a/src/main/php/xp/web/dev/console.html
+++ b/src/main/php/xp/web/dev/console.html
@@ -1,32 +1,43 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>{{kind}}</title>
+    <title>Console: {{kind}}</title>
     <style type="text/css">
-      body         { font-family: "Segoe UI",Arial,Helvetica; background-color: rgb(27, 43, 52); color: rgb(205, 211, 222); }
-      #content     { margin: 2em; }
-      h1 img       { float: left; margin-right: 0.5em; }
-      h1 #code     { padding: 0.1em 0.5em; background-color: rgb(102, 153, 204); color: white; border-radius: 0.1em; text-transform: uppercase; }
-      #debug       { border: 1px dotted rgb(205, 211, 222); overflow: hidden; padding: 0.5em; font-size: 13px; }
+      body         { font-family: system-ui,Arial,Helvetica; background-color: rgb(33, 37, 41); color: rgb(205, 211, 222); }
+      .debug       { background-color: rgb(102, 153, 204); }
+      .error       { background-color: rgb(204, 0, 0); }
+      main         { margin: 2rem 1rem; }
+      h1           { display: flex; align-items: center; color: white; border-radius: .25rem; width: fit-content; }
+      h1 svg       { margin-left: 1rem; }
+      #code        { margin: .25rem 1rem; text-transform: uppercase; }
+      #debug       { background-color: rgb(27, 43, 52); border-radius: .25rem; overflow: hidden; padding: .5rem; font-size: .925rem; }
+      #status      { color: rgb(102, 153, 204); }
       button.clip  { float: right; }
-      h2 #status   { color: rgb(102, 153, 204); }
-      table        { margin-bottom: 1.5em; }
-      td           { padding: 0.3em; }
-      td.name      { background-color: rgb(41, 56, 65); }
-      td.value     { color: rgb(249, 145, 87); font-family: monospace; font-size: 13px; }
-      button       { background-color: rgb(41, 56, 65); cursor: pointer; border-radius: 0.1em; border: none; }
-      button:hover { opacity: .65; transition: all 150ms linear; }
+      table        { margin-bottom: 1.5rem; }
+      td           { padding: .25rem; }
+      td.name      { background-color: rgb(27, 43, 52); }
+      td.value     { color: rgb(249, 145, 87); font-family: monospace; font-size: .925rem; }
+      button       { background-color: rgb(61, 76, 85); color: white; cursor: pointer; padding: .25rem .5rem; border-radius: .15rem; border: none; }
+      button:hover { background-color: rgb(102, 153, 204); transition: all 150ms; }
     </style>
   </head>
   <body bgcolor="#ffffff" text="#000000">
-    <div id="content">
-      <h1>
-        <img width="59" height="48" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADsAAAAwCAYAAACv4gJwAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAEeSURBVGhD7ZdNCsIwEEaj1/AILvUCHsStuPIwrsStB/EEnkmTkoESMklq85/vgQwFS+frm2npZrc/fsUgbHUdAoTtFYTtFW/Y0+3RVHXBvnrUye/7VR+1g6tvvGdDRqJmuP6HMmsNG7qvJSYgtC/b/6xj3OKDac6iB5TPLBl9XQ5Tzcn5+Zmqrz+YjWGW7nZKzGvBrIbrP+p7Vt19+tFxCbj+o5tVY0ajpmqJwFnMKkyzOfbZJItZsjo3W4JsZmsg287WAMxKYBZmGwJmJUOZxfcszFrgdiMloX3B7BqzIZB9136H7OESYFaSzCwZ/YcY14bZ1DtbAq5/a9hesY6xYs3OlcTVNxuWxoBObqW61g9j3CsI2ysI2ysDhRXiB5CuA+ASNuP/AAAAAElFTkSuQmCC" alt="Debug"/>
-
+    <main>
+      <!-- Debug output -->
+      <h1 class="{{kind}}">
+        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-bug" viewBox="0 0 16 16">
+          <path d="M4.355.522a.5.5 0 0 1 .623.333l.291.956A5 5 0 0 1 8 1c1.007 0 1.946.298 2.731.811l.29-.956a.5.5 0 1 1 .957.29l-.41 1.352A5 5 0 0 1 13 6h.5a.5.5 0 0 0 .5-.5V5a.5.5 0 0 1 1 0v.5A1.5 1.5 0 0 1 13.5 7H13v1h1.5a.5.5 0 0 1 0 1H13v1h.5a1.5 1.5 0 0 1 1.5 1.5v.5a.5.5 0 1 1-1 0v-.5a.5.5 0 0 0-.5-.5H13a5 5 0 0 1-10 0h-.5a.5.5 0 0 0-.5.5v.5a.5.5 0 1 1-1 0v-.5A1.5 1.5 0 0 1 2.5 10H3V9H1.5a.5.5 0 0 1 0-1H3V7h-.5A1.5 1.5 0 0 1 1 5.5V5a.5.5 0 0 1 1 0v.5a.5.5 0 0 0 .5.5H3c0-1.364.547-2.601 1.432-3.503l-.41-1.352a.5.5 0 0 1 .333-.623M4 7v4a4 4 0 0 0 3.5 3.97V7zm4.5 0v7.97A4 4 0 0 0 12 11V7zM12 6a4 4 0 0 0-1.334-2.982A3.98 3.98 0 0 0 8 2a3.98 3.98 0 0 0-2.667 1.018A4 4 0 0 0 4 6z"/>
+        </svg>
         <span id="code">{{kind}}</span>
       </h1>
       <div id="debug">
-        <button class="clip" title="Copy to clipboard" onclick="clip(document.getElementById('output').innerText); flash(document.getElementById('debug'))">📋</button>
+        <button class="clip" title="Copy to clipboard" onclick="clip(document.getElementById('output').innerText); flash(document.getElementById('debug'))">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-clipboard-plus" viewBox="0 0 16 16">
+            <path fill-rule="evenodd" d="M8 7a.5.5 0 0 1 .5.5V9H10a.5.5 0 0 1 0 1H8.5v1.5a.5.5 0 0 1-1 0V10H6a.5.5 0 0 1 0-1h1.5V7.5A.5.5 0 0 1 8 7"/>
+            <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1z"/>
+            <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0z"/>
+          </svg>
+        </button>
         <pre id="output">{{debug}}</pre>
       </div>
 
@@ -35,8 +46,8 @@
       <table id="headers">
         {{#rows headers}}
       </table>
-      <pre id="body">{{content}}</pre>
-    </div>
+      <pre id="body">{{contents}}</pre>
+    </main>
     <script type="text/javascript">
       function clip(text) {
         if (window.clipboardData) {
@@ -59,9 +70,9 @@
       }
 
       function flash(div) {
-        div.style.transition = 'all 150ms linear';
-        div.style.backgroundColor = 'rgb(41, 56, 65)';
-        setTimeout(function() { div.style.backgroundColor = null; }, 100);
+        div.style.transition = 'all 200ms linear';
+        div.style.backgroundColor = 'rgb(61, 76, 85)';
+        setTimeout(function() { div.style.backgroundColor = null; }, 200);
       }
     </script>
   </body>


### PR DESCRIPTION
This pull rqquest displays exceptions (alongside potential debug output) inside the developer console instead of falling through to the default error handling mechanism. It also modernizes the design a bit, see #53

## Before

* Debug output is displayed in the developer console
* Exceptions fall through and trigger the default error handling mechanism
* Debug output generated before thrown exceptions is swallowed

### Debug:
![Debug page](https://github.com/xp-forge/web/assets/696742/6662bcc7-9dd3-462f-9ee5-ff92221abe4b)

### Error:
![Error page](https://github.com/xp-forge/web/assets/696742/9d9d1efc-e38e-4b3a-b1ee-8b3869cb113e)

## After

* Debug output as well as exceptions are both displayed in the developer console
* Design consistently uses dark mode for developer tools
* Developer console has a 100 Lighthouse score

### Debug:
![Debug page](https://github.com/xp-forge/web/assets/696742/8f347186-45d4-4069-a967-5ca14298100c)

### Error:

![Error page](https://github.com/xp-forge/web/assets/696742/19778b8a-fb20-455f-be59-89f613a73bd6)
