### PR TITLE
Allow absolute paths in Environment::path()

### DIFF
--- a/src/main/php/web/Environment.class.php
+++ b/src/main/php/web/Environment.class.php
@@ -73,7 +73,8 @@ class Environment {
    * @return io.Path
    */
   public function path($path) {
-    return new Path($this->webroot, $path);
+    $p= $path instanceof Path ? $path : new Path($path);
+    return $p->isAbsolute() ? $p : new Path($this->webroot, $p);
   }
 
   /**

--- a/src/test/php/web/unittest/EnvironmentTest.class.php
+++ b/src/test/php/web/unittest/EnvironmentTest.class.php
@@ -3,6 +3,7 @@
 use io\{File, Files, Path};
 use lang\{ElementNotFoundException, Environment as System};
 use test\{Assert, Expect, Test, Values};
+use test\verify\Runtime;
 use util\{Properties, PropertySource, RegisteredPropertySource};
 use web\{Environment, Logging};
 
@@ -86,6 +87,33 @@ class EnvironmentTest {
     Assert::equals(
       new Path($environment->webroot(), 'src/main/handlebars'),
       $environment->path('src/main/handlebars')
+    );
+  }
+
+  #[Test]
+  public function relative_path() {
+    $environment= new Environment('dev', '.', 'static', []);
+    Assert::equals(
+      new Path($environment->webroot(), 'src/main/handlebars'),
+      $environment->path('src/main/handlebars')
+    );
+  }
+
+  #[Test, Runtime(os: 'BSD|Darwin|Solaris|Linux')]
+  public function absolute_unix_path() {
+    $environment= new Environment('dev', '.', 'static', []);
+    Assert::equals(
+      new Path('/etc'),
+      $environment->path('/etc')
+    );
+  }
+
+  #[Test, Runtime(os: 'Windows')]
+  public function absolute_windows_path() {
+    $environment= new Environment('dev', '.', 'static', []);
+    Assert::equals(
+      new Path('C:\\Windows'),
+      $environment->path('C:\\Windows')
     );
   }
 


### PR DESCRIPTION
Unchanged behavior with relative paths:
```bash
$ xp -w 'use web\Environment; (new Environment(getcwd()))->path($argv[1])' src/main/php/
./src/main/php/
```

Changed behavior with absolute paths:
```bash
# Before
$ xp -w 'use web\Environment; (new Environment(getcwd()))->path($argv[1])' /etc
.//etc

# After
$ xp -w 'use web\Environment; (new Environment(getcwd()))->path($argv[1])' /etc
/etc
```

See https://github.com/xp-forge/web/issues/124#issuecomment-3015567748