### PR TITLE
Verify websocket origin

### DIFF
--- a/src/test/php/web/unittest/handler/WebSocketTest.class.php
+++ b/src/test/php/web/unittest/handler/WebSocketTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace web\unittest\handler;
 
-use test\{Assert, Test};
+use test\{Assert, Test, Values};
 use util\Bytes;
 use web\handler\WebSocket;
 use web\io\{TestInput, TestOutput};
@@ -9,7 +9,7 @@ use web\{Request, Response};
 class WebSocketTest {
 
   /** Handles a request and returns the response generated from the handler */
-  private function handle(Request $request): Response {
+  private function handle(Request $request, $origins= ['*']): Response {
     $response= new Response(new TestOutput());
     $echo= function($conn, $payload) {
       if ($payload instanceof Bytes) {
@@ -18,8 +18,23 @@ class WebSocketTest {
         $conn->send('Re: '.$payload);
       }
     };
-    (new WebSocket($echo))->handle($request, $response)->next();
+    (new WebSocket($echo, $origins))->handle($request, $response)->next();
     return $response;
+  }
+
+  /** @return iterable */
+  private function origins() {
+
+    // We allow all ports and schemes on localhost
+    yield ['http://localhost', 101];
+    yield ['https://localhost', 101];
+    yield ['http://localhost:8080', 101];
+    yield ['https://localhost:8443', 101];
+
+    // Not allowed: localhost subdomains and unrelated domains
+    yield ['http://example.localhost', 403];
+    yield ['http://localhost.example.com', 403];
+    yield ['http://evil.example.com', 403];
   }
 
   #[Test]
@@ -30,6 +45,7 @@ class WebSocketTest {
   #[Test]
   public function switching_protocols() {
     $response= $this->handle(new Request(new TestInput('GET', '/ws', [
+      'Origin'                => 'http://localhost:8080',
       'Sec-WebSocket-Version' => 13,
       'Sec-WebSocket-Key'     => 'test',
     ])));
@@ -38,8 +54,30 @@ class WebSocketTest {
   }
 
   #[Test]
+  public function missing_origin() {
+    $request= new Request(new TestInput('GET', '/ws', [
+      'Sec-WebSocket-Version' => 13,
+      'Sec-WebSocket-Key'     => 'test',
+    ]));
+
+    Assert::equals(403, $this->handle($request)->status());
+  }
+
+  #[Test, Values(from: 'origins')]
+  public function verify_localhost_origin($origin, $expected) {
+    $request= new Request(new TestInput('GET', '/ws', [
+      'Origin'                => $origin,
+      'Sec-WebSocket-Version' => 13,
+      'Sec-WebSocket-Key'     => 'test',
+    ]));
+
+    Assert::equals($expected, $this->handle($request, ['*://localhost:*'])->status());
+  }
+
+  #[Test]
   public function translate_text_message() {
     $response= $this->handle(new Request(new TestInput('POST', '/ws', [
+      'Origin'                => 'http://localhost:8080',
       'Sec-WebSocket-Version' => 9,
       'Sec-WebSocket-Id'      => 123,
       'Content-Type'          => 'text/plain',
@@ -53,6 +91,7 @@ class WebSocketTest {
   #[Test]
   public function translate_binary_message() {
     $response= $this->handle(new Request(new TestInput('POST', '/ws', [
+      'Origin'                => 'http://localhost:8080',
       'Sec-WebSocket-Version' => 9,
       'Sec-WebSocket-Id'      => 123,
       'Content-Type'          => 'application/octet-stream',


### PR DESCRIPTION
> Note: All browsers send an Origin header. You can use this header for security (checking for same origin, automatically allowing or denying, etc.) and send a 403 Forbidden if you don't like what you see. This is effective against Cross Site WebSocket Hijacking (CSWH). However, be warned that non-browser agents can send a faked Origin. Most applications reject requests without this header.

*Source: https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers*

See also https://www.christian-schneider.net/blog/cross-site-websocket-hijacking/

